### PR TITLE
init: scaffold routes

### DIFF
--- a/app/(not-signed-in-only)/layout.tsx
+++ b/app/(not-signed-in-only)/layout.tsx
@@ -1,0 +1,7 @@
+import { type PropsWithChildren } from 'react';
+
+const NotSignedInOnlyLayout = ({ children }: PropsWithChildren) => {
+  return <>{children}</>;
+};
+
+export default NotSignedInOnlyLayout;

--- a/app/(not-signed-in-only)/sign-in/page.tsx
+++ b/app/(not-signed-in-only)/sign-in/page.tsx
@@ -1,0 +1,5 @@
+const SignInPage = () => {
+  return <div>SignInPage</div>;
+};
+
+export default SignInPage;

--- a/app/(public)/(main)/layout.tsx
+++ b/app/(public)/(main)/layout.tsx
@@ -1,0 +1,7 @@
+import { type PropsWithChildren } from 'react';
+
+const MainLayout = ({ children }: PropsWithChildren) => {
+  return <>{children}</>;
+};
+
+export default MainLayout;

--- a/app/(public)/(main)/page.tsx
+++ b/app/(public)/(main)/page.tsx
@@ -1,5 +1,5 @@
 const RootPage = () => {
-  return <main>Hello World 👋</main>;
+  return <div>RootPage</div>;
 };
 
 export default RootPage;

--- a/app/(public)/layout.tsx
+++ b/app/(public)/layout.tsx
@@ -1,0 +1,7 @@
+import { type PropsWithChildren } from 'react';
+
+const PublicLayout = ({ children }: PropsWithChildren) => {
+  return <>{children}</>;
+};
+
+export default PublicLayout;

--- a/app/(public)/search-user/page.tsx
+++ b/app/(public)/search-user/page.tsx
@@ -1,0 +1,5 @@
+const SearchUserPage = () => {
+  return <div>SearchUserPage</div>;
+};
+
+export default SearchUserPage;

--- a/app/(public)/users/[username]/page.tsx
+++ b/app/(public)/users/[username]/page.tsx
@@ -1,0 +1,11 @@
+type UsernamePageProps = {
+  params: {
+    username: string;
+  };
+};
+
+const UsernamePage = ({ params: { username } }: UsernamePageProps) => {
+  return <div>UsernamePage (username: {username})</div>;
+};
+
+export default UsernamePage;

--- a/app/(public)/users/[username]/posts/[slug]/comments/page.tsx
+++ b/app/(public)/users/[username]/posts/[slug]/comments/page.tsx
@@ -1,0 +1,16 @@
+type CommentsPageProps = {
+  params: {
+    username: string;
+    slug: string;
+  };
+};
+
+const CommentsPage = ({ params: { username, slug } }: CommentsPageProps) => {
+  return (
+    <div>
+      CommentsPage (username: {username}, slug: {slug})
+    </div>
+  );
+};
+
+export default CommentsPage;

--- a/app/(public)/users/[username]/posts/[slug]/page.tsx
+++ b/app/(public)/users/[username]/posts/[slug]/page.tsx
@@ -1,0 +1,16 @@
+type PostPageProps = {
+  params: {
+    username: string;
+    slug: string;
+  };
+};
+
+const PostPage = ({ params: { username, slug } }: PostPageProps) => {
+  return (
+    <div>
+      PostPage (username: {username}, slug: {slug})
+    </div>
+  );
+};
+
+export default PostPage;

--- a/app/(signed-in-only)/categories/[categoryId]/edit/page.tsx
+++ b/app/(signed-in-only)/categories/[categoryId]/edit/page.tsx
@@ -1,0 +1,13 @@
+type CategoryIdEditPageProps = {
+  params: {
+    categoryId: number;
+  };
+};
+
+const CategoryIdEditPage = ({
+  params: { categoryId },
+}: CategoryIdEditPageProps) => {
+  return <div>CategoryIdEditPage (categoryId: {categoryId})</div>;
+};
+
+export default CategoryIdEditPage;

--- a/app/(signed-in-only)/categories/page.tsx
+++ b/app/(signed-in-only)/categories/page.tsx
@@ -1,0 +1,5 @@
+const CategoriesPage = () => {
+  return <div>CategoriesPage</div>;
+};
+
+export default CategoriesPage;

--- a/app/(signed-in-only)/layout.tsx
+++ b/app/(signed-in-only)/layout.tsx
@@ -1,0 +1,7 @@
+import { type PropsWithChildren } from 'react';
+
+const SignedInOnlyLayout = ({ children }: PropsWithChildren) => {
+  return <>{children}</>;
+};
+
+export default SignedInOnlyLayout;

--- a/app/(signed-in-only)/notifications/page.tsx
+++ b/app/(signed-in-only)/notifications/page.tsx
@@ -1,0 +1,5 @@
+const NotificationsPage = () => {
+  return <div>NotificationsPage</div>;
+};
+
+export default NotificationsPage;

--- a/app/(signed-in-only)/report/comments/[commentId]/page.tsx
+++ b/app/(signed-in-only)/report/comments/[commentId]/page.tsx
@@ -1,0 +1,13 @@
+type ReportCommentIdPageProps = {
+  params: {
+    commentId: number;
+  };
+};
+
+const ReportCommentIdPage = ({
+  params: { commentId },
+}: ReportCommentIdPageProps) => {
+  return <div>ReportCommentIdPage (commentId: {commentId})</div>;
+};
+
+export default ReportCommentIdPage;

--- a/app/(signed-in-only)/report/posts/[postId]/page.tsx
+++ b/app/(signed-in-only)/report/posts/[postId]/page.tsx
@@ -1,0 +1,11 @@
+type ReportPostIdPageProps = {
+  params: {
+    postId: number;
+  };
+};
+
+const ReportPostIdPage = ({ params: { postId } }: ReportPostIdPageProps) => {
+  return <div>ReportPostIdPage (postId: {postId})</div>;
+};
+
+export default ReportPostIdPage;

--- a/app/(signed-in-only)/settings/announcements/page.tsx
+++ b/app/(signed-in-only)/settings/announcements/page.tsx
@@ -1,0 +1,5 @@
+const AnnouncementsPage = () => {
+  return <div>AnnouncementsPage</div>;
+};
+
+export default AnnouncementsPage;

--- a/app/(signed-in-only)/settings/license/page.tsx
+++ b/app/(signed-in-only)/settings/license/page.tsx
@@ -1,0 +1,5 @@
+const LicensePage = () => {
+  return <div>LicensePage</div>;
+};
+
+export default LicensePage;

--- a/app/(signed-in-only)/settings/manage-accounts/leave/page.tsx
+++ b/app/(signed-in-only)/settings/manage-accounts/leave/page.tsx
@@ -1,0 +1,5 @@
+const LeavePage = () => {
+  return <div>LeavePage</div>;
+};
+
+export default LeavePage;

--- a/app/(signed-in-only)/settings/manage-accounts/page.tsx
+++ b/app/(signed-in-only)/settings/manage-accounts/page.tsx
@@ -1,0 +1,5 @@
+const ManageAccountsPage = () => {
+  return <div>ManageAccountsPage</div>;
+};
+
+export default ManageAccountsPage;

--- a/app/(signed-in-only)/settings/page.tsx
+++ b/app/(signed-in-only)/settings/page.tsx
@@ -1,0 +1,5 @@
+const SettingsPage = () => {
+  return <div>SettingsPage</div>;
+};
+
+export default SettingsPage;

--- a/app/(signed-in-only)/settings/send-feedback/page.tsx
+++ b/app/(signed-in-only)/settings/send-feedback/page.tsx
@@ -1,0 +1,5 @@
+const SendFeedbackPage = () => {
+  return <div>SendFeedbackPage</div>;
+};
+
+export default SendFeedbackPage;

--- a/app/(signed-in-only)/write/page.tsx
+++ b/app/(signed-in-only)/write/page.tsx
@@ -1,0 +1,5 @@
+const WritePage = () => {
+  return <div>WritePage</div>;
+};
+
+export default WritePage;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import localFont from 'next/font/local';
 
 import { type PropsWithChildren } from 'react';
 
+import { cn } from '@/lib/utils';
 import QueryProvider from '@/providers/query-provider';
 
 import './globals.css';
@@ -21,7 +22,9 @@ const RootLayout = ({ children }: PropsWithChildren) => {
   return (
     <html lang="ko-KR">
       <QueryProvider>
-        <body className={wantedSansVariable.className}>{children}</body>
+        <body className={cn(wantedSansVariable.className, 'bg-slate-100')}>
+          <div className="mx-auto min-h-dvh max-w-lg bg-white">{children}</div>
+        </body>
       </QueryProvider>
     </html>
   );

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,0 +1,8 @@
+import { type ClassValue, clsx } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+const cn = (...inputs: ClassValue[]) => {
+  return twMerge(clsx(inputs));
+};
+
+export { cn };

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -6,6 +6,10 @@ const nextConfig = {
         source: '/@:username',
         destination: '/users/:username',
       },
+      {
+        source: '/@:username/:slug/:path*',
+        destination: '/users/:username/posts/:slug/:path*',
+      },
     ];
   },
 };

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,13 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  async rewrites() {
+    return [
+      {
+        source: '/@:username',
+        destination: '/users/:username',
+      },
+    ];
+  },
+};
 
 export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "clsx": "^2.1.0",
     "next": "14.1.4",
     "react": "^18",
-    "react-dom": "^18"
+    "react-dom": "^18",
+    "tailwind-merge": "^2.2.2"
   },
   "devDependencies": {
     "@trivago/prettier-plugin-sort-imports": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@tanstack/react-query": "^5.29.0",
     "axios": "^1.6.8",
+    "clsx": "^2.1.0",
     "next": "14.1.4",
     "react": "^18",
     "react-dom": "^18"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ dependencies:
   axios:
     specifier: ^1.6.8
     version: 1.6.8
+  clsx:
+    specifier: ^2.1.0
+    version: 2.1.0
   next:
     specifier: 14.1.4
     version: 14.1.4(react-dom@18.2.0)(react@18.2.0)
@@ -1077,6 +1080,11 @@ packages:
 
   /client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
+    dev: false
+
+  /clsx@2.1.0:
+    resolution: {integrity: sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg==}
+    engines: {node: '>=6'}
     dev: false
 
   /color-convert@1.9.3:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ dependencies:
   react-dom:
     specifier: ^18
     version: 18.2.0(react@18.2.0)
+  tailwind-merge:
+    specifier: ^2.2.2
+    version: 2.2.2
 
 devDependencies:
   '@trivago/prettier-plugin-sort-imports':
@@ -176,7 +179,6 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       regenerator-runtime: 0.14.1
-    dev: true
 
   /@babel/template@7.24.0:
     resolution: {integrity: sha512-Bkf2q8lMB0AFpX0NFEqSbx1OkTHf0f+0j82mkw+ZpzBnkk7e9Ql0891vlfgi+kHwOk8tQjiQHpqh4LaSa0fKEA==}
@@ -3065,7 +3067,6 @@ packages:
 
   /regenerator-runtime@0.14.1:
     resolution: {integrity: sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==}
-    dev: true
 
   /regexp.prototype.flags@1.5.2:
     resolution: {integrity: sha512-NcDiDkTLuPR+++OCKB0nWafEmhg/Da8aUPLPMQbK+bxKKCm1/S5he+AqYa4PlMCVBalb4/yxIRub6qkEx5yJbw==}
@@ -3415,6 +3416,12 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
     dev: true
+
+  /tailwind-merge@2.2.2:
+    resolution: {integrity: sha512-tWANXsnmJzgw6mQ07nE3aCDkCK4QdT3ThPMCzawoYA2Pws7vSTCvz3Vrjg61jVUGfFZPJzxEP+NimbcW+EdaDw==}
+    dependencies:
+      '@babel/runtime': 7.24.4
+    dev: false
 
   /tailwindcss@3.4.3:
     resolution: {integrity: sha512-U7sxQk/n397Bmx4JHbJx/iSOOv5G+II3f1kpLpY2QeUv5DcPdcTsYLlusZfq1NthHS1c1cZoyFmmkex1rzke0A==}


### PR DESCRIPTION
## Summary

[피그마](https://www.figma.com/file/5k7EFuQKRQBVUvxbquFBm4/Team-Sprint?type=design&node-id=84-394&mode=design&t=bGOflsemw8bzWghF-0) 기준으로 기본 라우팅을 진행하였습니다. 

## Describe your changes

라우팅 분기 기준은 다음과 같습니다. 
- (not-signed-in-only) : 비로그인 유저만 허용
- (public) : 로그인한 유저, 비로그인 유저 모두 허용
- (signed-in-only) : 로그인한 유저만 허용

**not-signed-in-only 레이아웃**의 페이지 목록은 다음과 같습니다. 
| 페이지명 | 주소 | 설명 | 비고 |
| - | - | - | - |
| SignInPage | /sign-in | 로그인 페이지 | |

**public 레이아웃**의 페이지 목록은 다음과 같습니다. 
| 페이지명 | 주소 | 설명 | 비고 |
| - | - | - | - |
| RootPage | / | 기본 페이지 | 로그인한 유저는 컴포넌트 구성이 다름 |
| SearchUserPage | /search-user | 유저 검색 페이지 | |
| UsernamePage | /users/[username] | 유저 프로필 페이지 | **/@:username**로 접근 시 rewrites |
| PostPage | /users/[username]/posts/[slug] | 게시글 페이지 | **/@:username/:slug/:path***로 접근 시 rewrites |
| CommentsPage | /users/[username]/posts/[slug]/comments | 댓글 페이지 | **/@:username/:slug/:path***로 접근 시 rewrites |

**signed-in-only 레이아웃**의 페이지 목록은 다음과 같습니다. 
| 페이지명 | 주소 | 설명 | 비고 |
| - | - | - | - |
| CategoriesPage | /categories | 카테고리 페이지 | 본인 것만 조회 가능 |
| CategoryIdEditPage | /categories/[categoryId]/edit | 카테고리 수정 페이지 | 본인 것만 조회 가능 |
| NotificatiosPage | /notifications | 알림 페이지 | 본인 것만 조회 가능 |
| ReportCommentIdPage | /report/comments/[commentId] | 댓글 신고 페이지 | |
| ReportPostIdPage | /report/posts/[postId] | 게시글 신고 페이지 | |
| SettingsPage | /settings | 설정 페이지 | 본인 것만 조회 가능 |
| AnnouncementsPage | /settings/announcements | 공지사항 페이지 | 상동 |
| LicensePage | /settings/license | 라이센스 페이지 | 상동 |
| ManageAccountsPage | /settings/manage-accounts | 계정 관리 페이지 | 상동 |
| LeavePage | /settings/manage-accounts/leave | 계정 탈퇴 페이지 | 상동 |
| SendFeedbackPage | /settings/send-feedback | 피드백 보내기 페이지 | 상동 |
| WritePage | /write | 글쓰기 페이지 | 상태관리 방식을 정하지 않아 미제작 |

라우팅 관련하여 추가로 언급할 사항입니다. 
- (main) 레이아웃에서 하단 탭바 넣을 예정

추가 변경사항은 다음과 같습니다. 
- clsx, tailwind-merge 의존성 설치
- lib/utils에 cn 함수 제작
- 전체 페이지에 대하여 **max-w-lg** 적용