### PR TITLE
init: install swagger-typescript-api

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+API_URL=https://api.example.com

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ yarn-error.log*
 next-env.d.ts
 
 *storybook.log
+
+# env
+.env

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -21,11 +21,11 @@ const metadata: Metadata = {
 const RootLayout = ({ children }: PropsWithChildren) => {
   return (
     <html lang="ko-KR">
-      <QueryProvider>
-        <body className={cn(wantedSansVariable.className, 'bg-slate-100')}>
+      <body className={cn(wantedSansVariable.className, 'bg-slate-100')}>
+        <QueryProvider>
           <div className="mx-auto min-h-dvh max-w-lg bg-white">{children}</div>
-        </body>
-      </QueryProvider>
+        </QueryProvider>
+      </body>
     </html>
   );
 };

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,8 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   async rewrites() {
+    const API_URL = process.env.API_URL;
+
     return [
       {
         source: '/@:username',
@@ -9,6 +11,10 @@ const nextConfig = {
       {
         source: '/@:username/:slug/:path*',
         destination: '/users/:username/posts/:slug/:path*',
+      },
+      {
+        source: '/api/:path*',
+        destination: `${API_URL}/:path*`,
       },
     ];
   },

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -13,7 +13,7 @@ const nextConfig = {
         destination: '/users/:username/posts/:slug/:path*',
       },
       {
-        source: '/api/:path*',
+        source: '/proxy-api/:path*',
         destination: `${API_URL}/:path*`,
       },
     ];

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@storybook/nextjs": "^8.0.6",
     "@storybook/react": "^8.0.6",
     "@storybook/test": "^8.0.6",
+    "@tanstack/react-query-devtools": "^5.29.0",
     "@trivago/prettier-plugin-sort-imports": "^4.3.0",
     "@types/node": "^20",
     "@types/react": "^18",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "prepare": "husky install",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
-    "sta": "sta -p https://api.example.com/api-docs-json -o types -n __generated__.d.ts --no-client"
+    "sta": "sta -p https://api.example.com/api-docs-json -o types -n __generated__.d.ts --axios"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.3.4",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "prettier": "^3.2.5",
     "prettier-plugin-tailwindcss": "^0.5.13",
     "storybook": "^8.0.6",
+    "swagger-typescript-api": "^13.0.3",
     "tailwindcss": "^3.3.0",
     "typescript": "^5"
   },

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "axios": "^1.6.8",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
+    "date-fns": "^3.6.0",
     "framer-motion": "^11.0.25",
     "lucide-react": "^0.365.0",
     "next": "14.1.4",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "lint:fix": "next lint --fix",
     "prepare": "husky install",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build"
+    "build-storybook": "storybook build",
+    "sta": "sta -p https://api.example.com/api-docs-json -o types -n __generated__.d.ts --no-client"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.3.4",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "axios": "^1.6.8",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
+    "framer-motion": "^11.0.25",
     "lucide-react": "^0.365.0",
     "next": "14.1.4",
     "react": "^18",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,6 +106,9 @@ devDependencies:
   '@storybook/test':
     specifier: ^8.0.6
     version: 8.0.6
+  '@tanstack/react-query-devtools':
+    specifier: ^5.29.0
+    version: 5.29.0(@tanstack/react-query@5.29.0)(react@18.2.0)
   '@trivago/prettier-plugin-sort-imports':
     specifier: ^4.3.0
     version: 4.3.0(prettier@3.2.5)
@@ -3582,7 +3585,21 @@ packages:
 
   /@tanstack/query-core@5.29.0:
     resolution: {integrity: sha512-WgPTRs58hm9CMzEr5jpISe8HXa3qKQ8CxewdYZeVnA54JrPY9B1CZiwsCoLpLkf0dGRZq+LcX5OiJb0bEsOFww==}
-    dev: false
+
+  /@tanstack/query-devtools@5.28.10:
+    resolution: {integrity: sha512-5UN629fKa5/1K/2Pd26gaU7epxRrYiT1gy+V+pW5K6hnf1DeUKK3pANSb2eHKlecjIKIhTwyF7k9XdyE2gREvQ==}
+    dev: true
+
+  /@tanstack/react-query-devtools@5.29.0(@tanstack/react-query@5.29.0)(react@18.2.0):
+    resolution: {integrity: sha512-WLuaU6yM4KdvBimEP1Km5lM4/p1J40cMp5I5z0Mc6a8QbBUYLK8qJcGIKelfLfDp7KmEcr59tzbRTmdH/GWvzQ==}
+    peerDependencies:
+      '@tanstack/react-query': ^5.29.0
+      react: ^18.0.0
+    dependencies:
+      '@tanstack/query-devtools': 5.28.10
+      '@tanstack/react-query': 5.29.0(react@18.2.0)
+      react: 18.2.0
+    dev: true
 
   /@tanstack/react-query@5.29.0(react@18.2.0):
     resolution: {integrity: sha512-yxlhHB73jaBla6h5B6zPaGmQjokkzAhMHN4veotkPNiQ3Ac/mCxgABRZPsJJrgCTvhpcncBZcDBFxaR2B37vug==}
@@ -3591,7 +3608,6 @@ packages:
     dependencies:
       '@tanstack/query-core': 5.29.0
       react: 18.2.0
-    dev: false
 
   /@testing-library/dom@9.3.4:
     resolution: {integrity: sha512-FlS4ZWlp97iiNWig0Muq8p+3rVDjRiYE+YKGbAqXOu9nwJFFOdL00kFpz42M+4huzYi86vAK1sOOfyOG45muIQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -160,6 +160,9 @@ devDependencies:
   storybook:
     specifier: ^8.0.6
     version: 8.0.6(react-dom@18.2.0)(react@18.2.0)
+  swagger-typescript-api:
+    specifier: ^13.0.3
+    version: 13.0.3
   tailwindcss:
     specifier: ^3.3.0
     version: 3.4.3
@@ -1848,6 +1851,10 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
+  /@exodus/schemasafe@1.3.0:
+    resolution: {integrity: sha512-5Aap/GaRupgNx/feGBwLLTVv8OQFfv3pq2lPRzPg9R+IOBnDgghTGW7l7EuVXOvg5cc/xSAlRW8rBrjIC3Nvqw==}
+    dev: true
+
   /@fal-works/esbuild-plugin-global-externals@2.1.2:
     resolution: {integrity: sha512-cEee/Z+I12mZcFJshKcCqC8tuX5hG3s+d+9nZ3LabqKF1vKdF41B92pJVCBggjAGORAeOzyyDDKrZwIkLffeOQ==}
     dev: true
@@ -2678,6 +2685,11 @@ packages:
 
   /@sinclair/typebox@0.27.8:
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
+    dev: true
+
+  /@sindresorhus/is@3.1.2:
+    resolution: {integrity: sha512-JiX9vxoKMmu8Y3Zr2RVathBL1Cdu4Nt4MuNWemt1Nc06A0RAin9c5FArkhGsyMBWfCu4zj+9b+GxtjAnE4qqLQ==}
+    engines: {node: '>=10'}
     dev: true
 
   /@storybook/addon-a11y@8.0.6:
@@ -3902,6 +3914,10 @@ packages:
       '@types/send': 0.17.4
     dev: true
 
+  /@types/swagger-schema-official@2.0.22:
+    resolution: {integrity: sha512-7yQiX6MWSFSvc/1wW5smJMZTZ4fHOd+hqLr3qr/HONDxHEa2bnYAsOcGBOEqFIjd4yetwMOdEDdeW+udRAQnHA==}
+    dev: true
+
   /@types/unist@3.0.2:
     resolution: {integrity: sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ==}
     dev: true
@@ -5061,6 +5077,10 @@ packages:
       set-function-length: 1.2.2
     dev: true
 
+  /call-me-maybe@1.0.2:
+    resolution: {integrity: sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==}
+    dev: true
+
   /callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
@@ -5125,6 +5145,11 @@ packages:
   /chalk@5.3.0:
     resolution: {integrity: sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+    dev: true
+
+  /char-regex@1.0.2:
+    resolution: {integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==}
+    engines: {node: '>=10'}
     dev: true
 
   /check-error@1.0.3:
@@ -5247,6 +5272,15 @@ packages:
 
   /client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
+
+  /cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+    dev: true
 
   /clone-deep@4.0.1:
     resolution: {integrity: sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==}
@@ -5439,6 +5473,16 @@ packages:
       yaml: 1.10.2
     dev: true
 
+  /cosmiconfig@8.2.0:
+    resolution: {integrity: sha512-3rTMnFJA1tCOPwRxtgF4wd7Ab2qvDbL8jX+3smjIbS4HlZBagTlpERbdN7iAbWlrfxE3M8c27kTwTawQ7st+OQ==}
+    engines: {node: '>=14'}
+    dependencies:
+      import-fresh: 3.3.0
+      js-yaml: 4.1.0
+      parse-json: 5.2.0
+      path-type: 4.0.0
+    dev: true
+
   /cosmiconfig@8.3.6(typescript@5.4.4):
     resolution: {integrity: sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==}
     engines: {node: '>=14'}
@@ -5564,6 +5608,11 @@ packages:
 
   /damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
+    dev: true
+
+  /data-uri-to-buffer@4.0.1:
+    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
+    engines: {node: '>= 12'}
     dev: true
 
   /data-view-buffer@1.0.1:
@@ -5947,6 +5996,10 @@ packages:
   /emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
+  /emojilib@2.4.0:
+    resolution: {integrity: sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw==}
+    dev: true
+
   /emojis-list@3.0.0:
     resolution: {integrity: sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==}
     engines: {node: '>= 4'}
@@ -6132,6 +6185,10 @@ packages:
       is-callable: 1.2.7
       is-date-object: 1.0.5
       is-symbol: 1.0.4
+    dev: true
+
+  /es6-promise@3.3.1:
+    resolution: {integrity: sha512-SOp9Phqvqn7jtEUxPWdWfWoLmyt2VaJ6MpvP9Comy1MceMXqE6bxvaTu4iaxpYYPzhny28Lc+M87/c2cPK6lDg==}
     dev: true
 
   /esbuild-plugin-alias@0.2.1:
@@ -6560,6 +6617,11 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
+  /eta@2.2.0:
+    resolution: {integrity: sha512-UVQ72Rqjy/ZKQalzV5dCCJP80GrmPrMxh6NlNf+erV6ObL0ZFkhCstWRawS85z3smdr3d2wXPsZEY7rDPfGd2g==}
+    engines: {node: '>=6.0.0'}
+    dev: true
+
   /etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
@@ -6690,10 +6752,22 @@ packages:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
     dev: true
 
+  /fast-safe-stringify@2.1.1:
+    resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
+    dev: true
+
   /fastq@1.17.1:
     resolution: {integrity: sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==}
     dependencies:
       reusify: 1.0.4
+
+  /fetch-blob@3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.3.3
+    dev: true
 
   /fetch-retry@5.0.6:
     resolution: {integrity: sha512-3yurQZ2hD9VISAhJJP9bpYFNQrHHBXE2JxxjY5aLEcDi46RmAzJE2OC9FAde0yis5ElW0jTTzs0zfg/Cca4XqQ==}
@@ -6880,6 +6954,13 @@ packages:
       mime-types: 2.1.35
     dev: false
 
+  /formdata-polyfill@4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
+    dependencies:
+      fetch-blob: 3.2.0
+    dev: true
+
   /forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
@@ -6967,6 +7048,11 @@ packages:
   /gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
+
+  /get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+    dev: true
 
   /get-east-asian-width@1.2.0:
     resolution: {integrity: sha512-2nk+7SIVb14QrgXFHcm84tD4bKQz0RxPuMT8Ag5KPOq7J5fEmAg0UbXdTOSHqNuHSU28k55qnceesxXRZGzKWA==}
@@ -7325,6 +7411,10 @@ packages:
       setprototypeof: 1.2.0
       statuses: 2.0.1
       toidentifier: 1.0.1
+    dev: true
+
+  /http2-client@1.3.5:
+    resolution: {integrity: sha512-EC2utToWl4RKfs5zd36Mxq7nzHHBuomZboI0yYL6Y0RmBgT7Sgkq4rQ0ezFTYoIsSs7Tm9SJe+o2FcAg6GBhGA==}
     dev: true
 
   /https-browserify@1.0.0:
@@ -8124,6 +8214,13 @@ packages:
       semver: 6.3.1
     dev: true
 
+  /make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
+    dependencies:
+      semver: 7.6.0
+    dev: true
+
   /map-or-similar@1.5.0:
     resolution: {integrity: sha512-0aF7ZmVon1igznGI4VS30yugpduQW3y3GkcgGJOp7d8x8QrizhigUxjI/m2UojsXXto+jLAH3KSz+xOJTiORjg==}
     dev: true
@@ -8321,6 +8418,12 @@ packages:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
+  /nanoid@3.3.6:
+    resolution: {integrity: sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+    dev: true
+
   /nanoid@3.3.7:
     resolution: {integrity: sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -8410,6 +8513,27 @@ packages:
       minimatch: 3.1.2
     dev: true
 
+  /node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    dev: true
+
+  /node-emoji@2.1.0:
+    resolution: {integrity: sha512-tcsBm9C6FmPN5Wo7OjFi9lgMyJjvkAeirmjR/ax8Ttfqy4N8PoFic26uqFTIgayHPNI5FH4ltUvfh9kHzwcK9A==}
+    dependencies:
+      '@sindresorhus/is': 3.1.2
+      char-regex: 1.0.2
+      emojilib: 2.4.0
+      skin-tone: 2.0.0
+    dev: true
+
+  /node-fetch-h2@2.3.0:
+    resolution: {integrity: sha512-ofRW94Ab0T4AOh5Fk8t0h8OBWrmjb0SSB20xh1H8YnPV9EJ+f5AMoYSUQ2zgJ4Iq2HAK0I2l5/Nequ8YzFS3Hg==}
+    engines: {node: 4.x || >=6.0.0}
+    dependencies:
+      http2-client: 1.3.5
+    dev: true
+
   /node-fetch-native@1.6.4:
     resolution: {integrity: sha512-IhOigYzAKHd244OC0JIMIUrjzctirCmPkaIfhDeGcEETWof5zKYUW7e7MYvChGWh/4CJeXEgsRyGzuF334rOOQ==}
     dev: true
@@ -8424,6 +8548,15 @@ packages:
         optional: true
     dependencies:
       whatwg-url: 5.0.0
+    dev: true
+
+  /node-fetch@3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dependencies:
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
     dev: true
 
   /node-polyfill-webpack-plugin@2.0.1(webpack@5.91.0):
@@ -8458,6 +8591,12 @@ packages:
       util: 0.12.5
       vm-browserify: 1.1.2
       webpack: 5.91.0(esbuild@0.20.2)
+    dev: true
+
+  /node-readfiles@0.2.0:
+    resolution: {integrity: sha512-SU00ZarexNlE4Rjdm83vglt5Y9yiQ+XI1XpflWlb7q7UTN1JUItm69xMeiQCTxtTfnzt+83T8Cx+vI2ED++VDA==}
+    dependencies:
+      es6-promise: 3.3.1
     dev: true
 
   /node-releases@2.0.14:
@@ -8511,6 +8650,48 @@ packages:
       execa: 8.0.1
       pathe: 1.1.2
       ufo: 1.5.3
+    dev: true
+
+  /oas-kit-common@1.0.8:
+    resolution: {integrity: sha512-pJTS2+T0oGIwgjGpw7sIRU8RQMcUoKCDWFLdBqKB2BNmGpbBMH2sdqAaOXUg8OzonZHU0L7vfJu1mJFEiYDWOQ==}
+    dependencies:
+      fast-safe-stringify: 2.1.1
+    dev: true
+
+  /oas-linter@3.2.2:
+    resolution: {integrity: sha512-KEGjPDVoU5K6swgo9hJVA/qYGlwfbFx+Kg2QB/kd7rzV5N8N5Mg6PlsoCMohVnQmo+pzJap/F610qTodKzecGQ==}
+    dependencies:
+      '@exodus/schemasafe': 1.3.0
+      should: 13.2.3
+      yaml: 1.10.2
+    dev: true
+
+  /oas-resolver@2.5.6:
+    resolution: {integrity: sha512-Yx5PWQNZomfEhPPOphFbZKi9W93CocQj18NlD2Pa4GWZzdZpSJvYwoiuurRI7m3SpcChrnO08hkuQDL3FGsVFQ==}
+    hasBin: true
+    dependencies:
+      node-fetch-h2: 2.3.0
+      oas-kit-common: 1.0.8
+      reftools: 1.1.9
+      yaml: 1.10.2
+      yargs: 17.7.2
+    dev: true
+
+  /oas-schema-walker@1.1.5:
+    resolution: {integrity: sha512-2yucenq1a9YPmeNExoUa9Qwrt9RFkjqaMAA1X+U7sbb0AqBeTIdMHky9SQQ6iN94bO5NW0W4TRYXerG+BdAvAQ==}
+    dev: true
+
+  /oas-validator@5.0.8:
+    resolution: {integrity: sha512-cu20/HE5N5HKqVygs3dt94eYJfBi0TsZvPVXDhbXQHiEityDN+RROTleefoKRKKJ9dFAF2JBkDHgvWj0sjKGmw==}
+    dependencies:
+      call-me-maybe: 1.0.2
+      oas-kit-common: 1.0.8
+      oas-linter: 3.2.2
+      oas-resolver: 2.5.6
+      oas-schema-walker: 1.1.5
+      reftools: 1.1.9
+      should: 13.2.3
+      yaml: 1.10.2
     dev: true
 
   /object-assign@4.1.1:
@@ -9153,6 +9334,12 @@ packages:
       prettier: 3.2.5
     dev: true
 
+  /prettier@3.0.0:
+    resolution: {integrity: sha512-zBf5eHpwHOGPC47h0zrPyNn+eAEIdEzfywMoYn2XPi0P44Zp0tSq64rq0xAREh4auw2cJZHo9QUob+NqCQky4g==}
+    engines: {node: '>=14'}
+    hasBin: true
+    dev: true
+
   /prettier@3.2.5:
     resolution: {integrity: sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==}
     engines: {node: '>=14'}
@@ -9593,6 +9780,10 @@ packages:
       which-builtin-type: 1.1.3
     dev: true
 
+  /reftools@1.1.9:
+    resolution: {integrity: sha512-OVede/NQE13xBQ+ob5CKd5KyeJYU2YInb1bmV4nRoOfquZPkAkxuOXicSe1PvqIuZZ4kD13sPKBbR7UFDmli6w==}
+    dev: true
+
   /regenerate-unicode-properties@10.1.1:
     resolution: {integrity: sha512-X007RyZLsCJVVrjgEFVpLUTZwyOZk3oiL75ZcuYjlIWd6rNJtOjkBwQc5AsRrpbKVkxN6sklw/k/9m2jJYOf8Q==}
     engines: {node: '>=4'}
@@ -9680,6 +9871,11 @@ packages:
       htmlparser2: 6.1.0
       lodash: 4.17.21
       strip-ansi: 6.0.1
+    dev: true
+
+  /require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
     dev: true
 
   /require-from-string@2.0.2:
@@ -9989,6 +10185,44 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  /should-equal@2.0.0:
+    resolution: {integrity: sha512-ZP36TMrK9euEuWQYBig9W55WPC7uo37qzAEmbjHz4gfyuXrEUgF8cUvQVO+w+d3OMfPvSRQJ22lSm8MQJ43LTA==}
+    dependencies:
+      should-type: 1.4.0
+    dev: true
+
+  /should-format@3.0.3:
+    resolution: {integrity: sha512-hZ58adtulAk0gKtua7QxevgUaXTTXxIi8t41L3zo9AHvjXO1/7sdLECuHeIN2SRtYXpNkmhoUP2pdeWgricQ+Q==}
+    dependencies:
+      should-type: 1.4.0
+      should-type-adaptors: 1.1.0
+    dev: true
+
+  /should-type-adaptors@1.1.0:
+    resolution: {integrity: sha512-JA4hdoLnN+kebEp2Vs8eBe9g7uy0zbRo+RMcU0EsNy+R+k049Ki+N5tT5Jagst2g7EAja+euFuoXFCa8vIklfA==}
+    dependencies:
+      should-type: 1.4.0
+      should-util: 1.0.1
+    dev: true
+
+  /should-type@1.4.0:
+    resolution: {integrity: sha512-MdAsTu3n25yDbIe1NeN69G4n6mUnJGtSJHygX3+oN0ZbO3DTiATnf7XnYJdGT42JCXurTb1JI0qOBR65shvhPQ==}
+    dev: true
+
+  /should-util@1.0.1:
+    resolution: {integrity: sha512-oXF8tfxx5cDk8r2kYqlkUJzZpDBqVY/II2WhvU0n9Y3XYvAYRmeaf1PvvIvTgPnv4KJ+ES5M0PyDq5Jp+Ygy2g==}
+    dev: true
+
+  /should@13.2.3:
+    resolution: {integrity: sha512-ggLesLtu2xp+ZxI+ysJTmNjh2U0TsC+rQ/pfED9bUZZ4DKefP27D+7YJVVTvKsmjLpIi9jAa7itwDGkDDmt1GQ==}
+    dependencies:
+      should-equal: 2.0.0
+      should-format: 3.0.3
+      should-type: 1.4.0
+      should-type-adaptors: 1.1.0
+      should-util: 1.0.1
+    dev: true
+
   /side-channel@1.0.6:
     resolution: {integrity: sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==}
     engines: {node: '>= 0.4'}
@@ -10027,6 +10261,13 @@ packages:
 
   /sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
+    dev: true
+
+  /skin-tone@2.0.0:
+    resolution: {integrity: sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==}
+    engines: {node: '>=8'}
+    dependencies:
+      unicode-emoji-modifier-base: 1.0.0
     dev: true
 
   /slash@3.0.0:
@@ -10370,6 +10611,51 @@ packages:
   /supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+
+  /swagger-schema-official@2.0.0-bab6bed:
+    resolution: {integrity: sha512-rCC0NWGKr/IJhtRuPq/t37qvZHI/mH4I4sxflVM+qgVe5Z2uOCivzWaVbuioJaB61kvm5UvB7b49E+oBY0M8jA==}
+    dev: true
+
+  /swagger-typescript-api@13.0.3:
+    resolution: {integrity: sha512-774ndLpGm2FNpUZpDugfoOO2pIcvSW9nlcqwLVSH9ju4YKCi1Gd83jPly7upcljOvZ8KO/edIUx+9eYViDYglg==}
+    hasBin: true
+    dependencies:
+      '@types/swagger-schema-official': 2.0.22
+      cosmiconfig: 8.2.0
+      didyoumean: 1.2.2
+      eta: 2.2.0
+      js-yaml: 4.1.0
+      lodash: 4.17.21
+      make-dir: 4.0.0
+      nanoid: 3.3.6
+      node-emoji: 2.1.0
+      node-fetch: 3.3.2
+      prettier: 3.0.0
+      swagger-schema-official: 2.0.0-bab6bed
+      swagger2openapi: 7.0.8
+      typescript: 5.1.6
+    transitivePeerDependencies:
+      - encoding
+    dev: true
+
+  /swagger2openapi@7.0.8:
+    resolution: {integrity: sha512-upi/0ZGkYgEcLeGieoz8gT74oWHA0E7JivX7aN9mAf+Tc7BQoRBvnIGHoPDw+f9TXTW4s6kGYCZJtauP6OYp7g==}
+    hasBin: true
+    dependencies:
+      call-me-maybe: 1.0.2
+      node-fetch: 2.7.0
+      node-fetch-h2: 2.3.0
+      node-readfiles: 0.2.0
+      oas-kit-common: 1.0.8
+      oas-resolver: 2.5.6
+      oas-schema-walker: 1.1.5
+      oas-validator: 5.0.8
+      reftools: 1.1.9
+      yaml: 1.10.2
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - encoding
+    dev: true
 
   /tailwind-merge@2.2.2:
     resolution: {integrity: sha512-tWANXsnmJzgw6mQ07nE3aCDkCK4QdT3ThPMCzawoYA2Pws7vSTCvz3Vrjg61jVUGfFZPJzxEP+NimbcW+EdaDw==}
@@ -10772,6 +11058,12 @@ packages:
       possible-typed-array-names: 1.0.0
     dev: true
 
+  /typescript@5.1.6:
+    resolution: {integrity: sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+    dev: true
+
   /typescript@5.4.4:
     resolution: {integrity: sha512-dGE2Vv8cpVvw28v8HCPqyb08EzbBURxDpuhJvTrusShUfGnhHBafDsLdS1EhhxyL6BJQE+2cT3dDPAv+MQ6oLw==}
     engines: {node: '>=14.17'}
@@ -10805,6 +11097,11 @@ packages:
 
   /unicode-canonical-property-names-ecmascript@2.0.0:
     resolution: {integrity: sha512-yY5PpDlfVIU5+y/BSCxAJRBIS1Zc2dDG3Ujq+sR0U+JjUevW2JhocOF+soROYDSaAezOzOKuyyixhD6mBknSmQ==}
+    engines: {node: '>=4'}
+    dev: true
+
+  /unicode-emoji-modifier-base@1.0.0:
+    resolution: {integrity: sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g==}
     engines: {node: '>=4'}
     dev: true
 
@@ -10988,6 +11285,11 @@ packages:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
     dependencies:
       defaults: 1.0.4
+    dev: true
+
+  /web-streams-polyfill@3.3.3:
+    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
+    engines: {node: '>= 8'}
     dev: true
 
   /webidl-conversions@3.0.1:
@@ -11194,6 +11496,11 @@ packages:
     engines: {node: '>=0.4'}
     dev: true
 
+  /y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+    dev: true
+
   /yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
@@ -11215,6 +11522,24 @@ packages:
     resolution: {integrity: sha512-pIXzoImaqmfOrL7teGUBt/T7ZDnyeGBWyXQBvOVhLkWLN37GXv8NMLK406UY6dS51JfcQHsmcW5cJ441bHg6Lg==}
     engines: {node: '>= 14'}
     hasBin: true
+
+  /yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+    dev: true
+
+  /yargs@17.7.2:
+    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
+    engines: {node: '>=12'}
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.1.2
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
+    dev: true
 
   /yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ dependencies:
   clsx:
     specifier: ^2.1.0
     version: 2.1.0
+  date-fns:
+    specifier: ^3.6.0
+    version: 3.6.0
   framer-motion:
     specifier: ^11.0.25
     version: 11.0.25(react-dom@18.2.0)(react@18.2.0)
@@ -5644,6 +5647,10 @@ packages:
       es-errors: 1.3.0
       is-data-view: 1.0.1
     dev: true
+
+  /date-fns@3.6.0:
+    resolution: {integrity: sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==}
+    dev: false
 
   /debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ dependencies:
   clsx:
     specifier: ^2.1.0
     version: 2.1.0
+  framer-motion:
+    specifier: ^11.0.25
+    version: 11.0.25(react-dom@18.2.0)(react@18.2.0)
   lucide-react:
     specifier: ^0.365.0
     version: 0.365.0(react@18.2.0)
@@ -6969,6 +6972,25 @@ packages:
   /fraction.js@4.3.7:
     resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
     dev: true
+
+  /framer-motion@11.0.25(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-mRt7vQGzA7++wTgb+PW1TrlXXgndqR6hCiJ48fXr2X9alte2hPQiAq556HRwDCt0Q5X98MNvcSe4KUa27Gm5Lg==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0
+      react-dom: ^18.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+    dependencies:
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      tslib: 2.6.2
+    dev: false
 
   /fresh@0.5.2:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}

--- a/providers/query-provider.tsx
+++ b/providers/query-provider.tsx
@@ -3,12 +3,16 @@
 import { type PropsWithChildren, useState } from 'react';
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 
 const QueryProvider = ({ children }: PropsWithChildren) => {
   const [queryClient] = useState(() => new QueryClient());
 
   return (
-    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    <QueryClientProvider client={queryClient}>
+      {children}
+      <ReactQueryDevtools initialIsOpen={false} />
+    </QueryClientProvider>
   );
 };
 

--- a/types/__generated__.d.ts
+++ b/types/__generated__.d.ts
@@ -1,5 +1,7 @@
 /* eslint-disable */
+
 /* tslint:disable */
+
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -8,6 +10,14 @@
  * ## SOURCE: https://github.com/acacode/swagger-typescript-api ##
  * ---------------------------------------------------------------
  */
+import type {
+  AxiosInstance,
+  AxiosRequestConfig,
+  AxiosResponse,
+  HeadersDefaults,
+  ResponseType,
+} from 'axios';
+import axios from 'axios';
 
 export interface CreateCommentInput {
   /** 루트 게시글 아이디 */
@@ -364,4 +374,1026 @@ export interface CreatePostCategoryResponseDto {
   name: string;
   /** 유저 kakaoId */
   user: number;
+}
+
+export type QueryParamsType = Record<string | number, any>;
+
+export interface FullRequestParams
+  extends Omit<AxiosRequestConfig, 'data' | 'params' | 'url' | 'responseType'> {
+  /** set parameter to `true` for call `securityWorker` for this request */
+  secure?: boolean;
+  /** request path */
+  path: string;
+  /** content type of request body */
+  type?: ContentType;
+  /** query params */
+  query?: QueryParamsType;
+  /** format of response (i.e. response.json() -> format: "json") */
+  format?: ResponseType;
+  /** request body */
+  body?: unknown;
+}
+
+export type RequestParams = Omit<
+  FullRequestParams,
+  'body' | 'method' | 'query' | 'path'
+>;
+
+export interface ApiConfig<SecurityDataType = unknown>
+  extends Omit<AxiosRequestConfig, 'data' | 'cancelToken'> {
+  securityWorker?: (
+    securityData: SecurityDataType | null,
+  ) => Promise<AxiosRequestConfig | void> | AxiosRequestConfig | void;
+  secure?: boolean;
+  format?: ResponseType;
+}
+
+export enum ContentType {
+  Json = 'application/json',
+  FormData = 'multipart/form-data',
+  UrlEncoded = 'application/x-www-form-urlencoded',
+  Text = 'text/plain',
+}
+
+export class HttpClient<SecurityDataType = unknown> {
+  public instance: AxiosInstance;
+  private securityData: SecurityDataType | null = null;
+  private securityWorker?: ApiConfig<SecurityDataType>['securityWorker'];
+  private secure?: boolean;
+  private format?: ResponseType;
+
+  constructor({
+    securityWorker,
+    secure,
+    format,
+    ...axiosConfig
+  }: ApiConfig<SecurityDataType> = {}) {
+    this.instance = axios.create({
+      ...axiosConfig,
+      baseURL: axiosConfig.baseURL || '',
+    });
+    this.secure = secure;
+    this.format = format;
+    this.securityWorker = securityWorker;
+  }
+
+  public setSecurityData = (data: SecurityDataType | null) => {
+    this.securityData = data;
+  };
+
+  protected mergeRequestParams(
+    params1: AxiosRequestConfig,
+    params2?: AxiosRequestConfig,
+  ): AxiosRequestConfig {
+    const method = params1.method || (params2 && params2.method);
+
+    return {
+      ...this.instance.defaults,
+      ...params1,
+      ...(params2 || {}),
+      headers: {
+        ...((method &&
+          this.instance.defaults.headers[
+            method.toLowerCase() as keyof HeadersDefaults
+          ]) ||
+          {}),
+        ...(params1.headers || {}),
+        ...((params2 && params2.headers) || {}),
+      },
+    };
+  }
+
+  protected stringifyFormItem(formItem: unknown) {
+    if (typeof formItem === 'object' && formItem !== null) {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
+  protected createFormData(input: Record<string, unknown>): FormData {
+    return Object.keys(input || {}).reduce((formData, key) => {
+      const property = input[key];
+      const propertyContent: any[] =
+        property instanceof Array ? property : [property];
+
+      for (const formItem of propertyContent) {
+        const isFileType = formItem instanceof Blob || formItem instanceof File;
+        formData.append(
+          key,
+          isFileType ? formItem : this.stringifyFormItem(formItem),
+        );
+      }
+
+      return formData;
+    }, new FormData());
+  }
+
+  public request = async <T = any, _E = any>({
+    secure,
+    path,
+    type,
+    query,
+    format,
+    body,
+    ...params
+  }: FullRequestParams): Promise<AxiosResponse<T>> => {
+    const secureParams =
+      ((typeof secure === 'boolean' ? secure : this.secure) &&
+        this.securityWorker &&
+        (await this.securityWorker(this.securityData))) ||
+      {};
+    const requestParams = this.mergeRequestParams(params, secureParams);
+    const responseFormat = format || this.format || undefined;
+
+    if (
+      type === ContentType.FormData &&
+      body &&
+      body !== null &&
+      typeof body === 'object'
+    ) {
+      body = this.createFormData(body as Record<string, unknown>);
+    }
+
+    if (
+      type === ContentType.Text &&
+      body &&
+      body !== null &&
+      typeof body !== 'string'
+    ) {
+      body = JSON.stringify(body);
+    }
+
+    return this.instance.request({
+      ...requestParams,
+      headers: {
+        ...(requestParams.headers || {}),
+        ...(type && type !== ContentType.FormData
+          ? { 'Content-Type': type }
+          : {}),
+      },
+      params: query,
+      responseType: responseFormat,
+      data: body,
+      url: path,
+    });
+  };
+}
+
+/**
+ * @title blccu.com
+ * @version 1.0
+ * @contact
+ *
+ * blccu.com API spec
+ */
+export class Api<
+  SecurityDataType extends unknown,
+> extends HttpClient<SecurityDataType> {
+  comments = {
+    /**
+     * @description 댓글을 작성하거나 (optional)id에 해당하는 댓글을 수정한다.
+     *
+     * @tags 댓글 API
+     * @name CommentsControllerUpsertComment
+     * @summary 댓글을 작성하거나 수정한다.
+     * @request POST:/comments
+     */
+    commentsControllerUpsertComment: (
+      data: CreateCommentInput,
+      params: RequestParams = {},
+    ) =>
+      this.request<void, any>({
+        path: `/comments`,
+        method: 'POST',
+        body: data,
+        type: ContentType.Json,
+        ...params,
+      }),
+
+    /**
+     * @description 댓글을 논리삭제한다. date_deleted 칼럼에 값이 생긴다.
+     *
+     * @tags 댓글 API
+     * @name CommentsControllerDeleteComment
+     * @summary 댓글을 삭제한다.
+     * @request DELETE:/comments
+     */
+    commentsControllerDeleteComment: (
+      data: DeleteCommentDto,
+      params: RequestParams = {},
+    ) =>
+      this.request<void, any>({
+        path: `/comments`,
+        method: 'DELETE',
+        body: data,
+        type: ContentType.Json,
+        ...params,
+      }),
+  };
+  users = {
+    /**
+     * @description 배포 때 삭제할 거임. 개발 및 테스트용
+     *
+     * @tags 유저 API
+     * @name UsersControllerFindAllUsers
+     * @summary [ONLY FOR DEV] 모든 유저의 정보를 조회한다
+     * @request GET:/users/all
+     */
+    usersControllerFindAllUsers: (params: RequestParams = {}) =>
+      this.request<void, any>({
+        path: `/users/all`,
+        method: 'GET',
+        ...params,
+      }),
+
+    /**
+     * @description 로그인된 유저의 정보를 불러온다.
+     *
+     * @tags 유저 API
+     * @name UsersControllerFetchUser
+     * @summary 로그인된 유저의 정보 불러오기
+     * @request GET:/users
+     * @secure
+     */
+    usersControllerFetchUser: (params: RequestParams = {}) =>
+      this.request<UserResponseDto, any>({
+        path: `/users`,
+        method: 'GET',
+        secure: true,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description 로그인된 유저의 이름이나 설명, 혹은 둘 다를 변경한다.
+     *
+     * @tags 유저 API
+     * @name UsersControllerPatchUser
+     * @summary 로그인된 유저의 이름이나 설명을 변경
+     * @request PATCH:/users
+     * @secure
+     */
+    usersControllerPatchUser: (
+      data: PatchUserInput,
+      params: RequestParams = {},
+    ) =>
+      this.request<PatchUserInput, any>({
+        path: `/users`,
+        method: 'PATCH',
+        body: data,
+        secure: true,
+        type: ContentType.Json,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description 스토리지에 프로필 사진을 업로드하고 변경한다.
+     *
+     * @tags 유저 API
+     * @name UsersControllerUploadProfileImage
+     * @summary 로그인된 유저의 프로필 이미지를 변경
+     * @request POST:/users/profile
+     * @secure
+     */
+    usersControllerUploadProfileImage: (
+      data: ImageUploadDto,
+      params: RequestParams = {},
+    ) =>
+      this.request<ImageUploadResponseDto, any>({
+        path: `/users/profile`,
+        method: 'POST',
+        body: data,
+        secure: true,
+        type: ContentType.FormData,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description 스토리지에 배경 사진을 업로드하고 변경한다.
+     *
+     * @tags 유저 API
+     * @name UsersControllerUploadBackgroundImage
+     * @summary 로그인된 유저의 배경 이미지를 변경
+     * @request POST:/users/background
+     * @secure
+     */
+    usersControllerUploadBackgroundImage: (
+      data: ImageUploadDto,
+      params: RequestParams = {},
+    ) =>
+      this.request<ImageUploadResponseDto, any>({
+        path: `/users/background`,
+        method: 'POST',
+        body: data,
+        secure: true,
+        type: ContentType.FormData,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description 이름에 username이 포함된 유저를 검색한다.
+     *
+     * @tags 유저 API
+     * @name UsersControllerFindUsersByName
+     * @summary 이름이 포함된 유저 검색
+     * @request GET:/users/username/{username}
+     */
+    usersControllerFindUsersByName: (
+      username: string,
+      params: RequestParams = {},
+    ) =>
+      this.request<UserResponseDto[], any>({
+        path: `/users/username/${username}`,
+        method: 'GET',
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description kakaoId가 param과 일치하는 유저를 검색한다.
+     *
+     * @tags 유저 API
+     * @name UsersControllerFindUserByKakaoId
+     * @summary kakaoId에 정확히 부합하는 유저 검색
+     * @request GET:/users/kakaoId/{kakaoId}
+     */
+    usersControllerFindUserByKakaoId: (
+      kakaoId: number,
+      params: RequestParams = {},
+    ) =>
+      this.request<UserResponseDto, any>({
+        path: `/users/kakaoId/${kakaoId}`,
+        method: 'GET',
+        format: 'json',
+        ...params,
+      }),
+  };
+  stickers = {
+    /**
+     * @description 개인만 조회 가능한 유저용 스티커를 업로드한다.
+     *
+     * @tags 스티커 API
+     * @name StickersControllerCreatePrivateSticker
+     * @summary [유저용] 개인 스티커를 업로드한다.
+     * @request POST:/stickers/private
+     * @secure
+     */
+    stickersControllerCreatePrivateSticker: (
+      data: ImageUploadDto,
+      params: RequestParams = {},
+    ) =>
+      this.request<Sticker, any>({
+        path: `/stickers/private`,
+        method: 'POST',
+        body: data,
+        secure: true,
+        type: ContentType.FormData,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description 본인이 만든 재사용 가능한 스티커들을 fetch한다.
+     *
+     * @tags 스티커 API
+     * @name StickersControllerFetchPrivateStickers
+     * @summary private 스티커를 fetch한다.
+     * @request GET:/stickers/private
+     * @secure
+     */
+    stickersControllerFetchPrivateStickers: (params: RequestParams = {}) =>
+      this.request<Sticker[], any>({
+        path: `/stickers/private`,
+        method: 'GET',
+        secure: true,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description 블꾸에서 제작한 스티커를 업로드한다. 어드민 권한이 있는 유저 전용. 카테고리와 매핑을 해주어야 조회 가능.
+     *
+     * @tags 스티커 API
+     * @name StickersControllerCreatePublicSticker
+     * @summary [어드민용] 공용 스티커를 업로드한다.
+     * @request POST:/stickers/public
+     * @secure
+     */
+    stickersControllerCreatePublicSticker: (
+      data: ImageUploadDto,
+      params: RequestParams = {},
+    ) =>
+      this.request<Sticker, void>({
+        path: `/stickers/public`,
+        method: 'POST',
+        body: data,
+        secure: true,
+        type: ContentType.FormData,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description 블꾸가 만든 스티커들을 fetch한다.
+     *
+     * @tags 스티커 API
+     * @name StickersControllerFetchPublicStickers
+     * @summary public 스티커를 fetch한다.
+     * @request GET:/stickers/public
+     */
+    stickersControllerFetchPublicStickers: (params: RequestParams = {}) =>
+      this.request<Sticker[], any>({
+        path: `/stickers/public`,
+        method: 'GET',
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description 본인이 만든 스티커의 재사용 여부를 토글한다. 보관함 저장 혹은 삭제 용도로 사용할 것
+     *
+     * @tags 스티커 API
+     * @name StickersControllerToggleReusable
+     * @summary 스티커 재사용 여부를 토글한다.
+     * @request POST:/stickers/{id}
+     * @secure
+     */
+    stickersControllerToggleReusable: (
+      id: number,
+      params: RequestParams = {},
+    ) =>
+      this.request<void, any>({
+        path: `/stickers/${id}`,
+        method: 'POST',
+        secure: true,
+        ...params,
+      }),
+  };
+  stickercg = {
+    /**
+     * @description [어드민 전용] 스티커 카테고리를 만든다.
+     *
+     * @tags 스티커 카테고리 API
+     * @name StickerCategoriesControllerCreateCategory
+     * @summary 스티커 카테고리 생성
+     * @request POST:/stickercg/{name}
+     * @secure
+     */
+    stickerCategoriesControllerCreateCategory: (
+      name: string,
+      params: RequestParams = {},
+    ) =>
+      this.request<StickerCategory, any>({
+        path: `/stickercg/${name}`,
+        method: 'POST',
+        secure: true,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description 카테고리를 이름으로 찾고, 이에 매핑된 스티커들을 가져온다
+     *
+     * @tags 스티커 카테고리 API
+     * @name StickerCategoriesControllerFetchStickersByCategoryName
+     * @summary 카테고리 이름에 해당하는 스티커를 fetchAll
+     * @request GET:/stickercg/{name}
+     */
+    stickerCategoriesControllerFetchStickersByCategoryName: (
+      name: string,
+      params: RequestParams = {},
+    ) =>
+      this.request<void, any>({
+        path: `/stickercg/${name}`,
+        method: 'GET',
+        ...params,
+      }),
+
+    /**
+     * @description [어드민 전용] 스티커에 카테고리를 매핑한다.
+     *
+     * @tags 스티커 카테고리 API
+     * @name StickerCategoriesControllerMapCategory
+     * @summary 스티커와 카테고리 매핑
+     * @request POST:/stickercg
+     * @secure
+     */
+    stickerCategoriesControllerMapCategory: (
+      data: MapCategoryDto,
+      params: RequestParams = {},
+    ) =>
+      this.request<void, any>({
+        path: `/stickercg`,
+        method: 'POST',
+        body: data,
+        secure: true,
+        type: ContentType.Json,
+        ...params,
+      }),
+
+    /**
+     * @description 카테고리를 모두 조회한다.
+     *
+     * @tags 스티커 카테고리 API
+     * @name StickerCategoriesControllerFetchCategories
+     * @summary 카테고리 fetchAll
+     * @request GET:/stickercg
+     */
+    stickerCategoriesControllerFetchCategories: (params: RequestParams = {}) =>
+      this.request<void, any>({
+        path: `/stickercg`,
+        method: 'GET',
+        ...params,
+      }),
+  };
+  stickerBlocks = {
+    /**
+     * @description 게시글과 스티커 아이디를 매핑한 스티커 블록을 생성한다. 세부 스타일 좌표값을 저장한다.
+     *
+     * @tags 스티커 블록 API
+     * @name StickerBlocksControllerCreateStickerBlock
+     * @summary 게시글 속 스티커 생성
+     * @request POST:/stickerBlocks
+     */
+    stickerBlocksControllerCreateStickerBlock: (
+      data: CreateStickerBlockDto,
+      params: RequestParams = {},
+    ) =>
+      this.request<void, any>({
+        path: `/stickerBlocks`,
+        method: 'POST',
+        body: data,
+        type: ContentType.Json,
+        ...params,
+      }),
+  };
+  posts = {
+    /**
+     * @description 게시글을 임시등록한다. id를 입력하지 않으면 생성하고 있는 아이디를 치면 update하는 로직으로 바로 게시글 생성에 사용해도 되고, 수정용으로 사용해도 된다.
+     *
+     * @tags 게시글 API
+     * @name PostsControllerUpdatePost
+     * @summary 게시글 임시등록
+     * @request POST:/posts/temp
+     */
+    postsControllerUpdatePost: (
+      data: CreatePostInput,
+      params: RequestParams = {},
+    ) =>
+      this.request<PublishPostDto, any>({
+        path: `/posts/temp`,
+        method: 'POST',
+        body: data,
+        type: ContentType.Json,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description 로그인된 유저의 임시작성 게시글을 조회한다.
+     *
+     * @tags 게시글 API
+     * @name PostsControllerFetchTempPosts
+     * @summary 임시작성 게시글 조회
+     * @request GET:/posts/temp
+     * @secure
+     */
+    postsControllerFetchTempPosts: (params: RequestParams = {}) =>
+      this.request<void, any>({
+        path: `/posts/temp`,
+        method: 'GET',
+        secure: true,
+        ...params,
+      }),
+
+    /**
+     * @description 게시글을 등록한다. id를 입력하지 않으면 생성하고 있는 아이디를 치면 update하는 로직으로 바로 게시글 생성에 사용해도 되고, 수정용으로 사용해도 된다.
+     *
+     * @tags 게시글 API
+     * @name PostsControllerPublishPost
+     * @summary 게시글 등록
+     * @request POST:/posts
+     */
+    postsControllerPublishPost: (
+      data: PublishPostInput,
+      params: RequestParams = {},
+    ) =>
+      this.request<PublishPostDto, any>({
+        path: `/posts`,
+        method: 'POST',
+        body: data,
+        type: ContentType.Json,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description Query를 통해 페이지네이션 가능. default) pageNo: 1, pageSize: 10
+     *
+     * @tags 게시글 API
+     * @name PostsControllerFetchPosts
+     * @summary 전체 게시글 조회 API
+     * @request GET:/posts
+     */
+    postsControllerFetchPosts: (
+      query?: {
+        /** 요청할 페이지 번호 */
+        pageNo?: number;
+        /** 한 페이지 당 아이템 갯수 */
+        pageSize?: number;
+      },
+      params: RequestParams = {},
+    ) =>
+      this.request<PagePostResponseDto, any>({
+        path: `/posts`,
+        method: 'GET',
+        query: query,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description 이미지를 서버에 업로드한다. url을 반환 받는다.
+     *
+     * @tags 게시글 API
+     * @name PostsControllerCreatePrivateSticker
+     * @summary 이미지 업로드
+     * @request POST:/posts/image
+     * @secure
+     */
+    postsControllerCreatePrivateSticker: (
+      data: ImageUploadDto,
+      params: RequestParams = {},
+    ) =>
+      this.request<ImageUploadResponseDto, any>({
+        path: `/posts/image`,
+        method: 'POST',
+        body: data,
+        secure: true,
+        type: ContentType.FormData,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description 친구의 게시글을 조회한다. Query를 통해 페이지네이션 가능. default) pageNo: 1, pageSize: 10
+     *
+     * @tags 게시글 API
+     * @name PostsControllerFetchFriendsPosts
+     * @summary 친구 게시글 조회
+     * @request GET:/posts/friends
+     * @secure
+     */
+    postsControllerFetchFriendsPosts: (
+      query?: {
+        /** 요청할 페이지 번호 */
+        pageNo?: number;
+        /** 한 페이지 당 아이템 갯수 */
+        pageSize?: number;
+      },
+      params: RequestParams = {},
+    ) =>
+      this.request<PagePostResponseDto, any>({
+        path: `/posts/friends`,
+        method: 'GET',
+        query: query,
+        secure: true,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description 로그인 된 유저의 {id}에 해당하는 게시글을 논리삭제한다. 발행된 게시글에 사용을 권장
+     *
+     * @tags 게시글 API
+     * @name PostsControllerSoftDelete
+     * @summary 게시글 soft delete
+     * @request DELETE:/posts/soft/{id}
+     * @secure
+     */
+    postsControllerSoftDelete: (id: number, params: RequestParams = {}) =>
+      this.request<void, any>({
+        path: `/posts/soft/${id}`,
+        method: 'DELETE',
+        secure: true,
+        ...params,
+      }),
+
+    /**
+     * @description 로그인 된 유저의 {id}에 해당하는 게시글을 물리삭제한다. 임시 저장된 게시글에 사용을 권장
+     *
+     * @tags 게시글 API
+     * @name PostsControllerHardDelete
+     * @summary 게시글 hard delete
+     * @request DELETE:/posts/hard/{id}
+     * @secure
+     */
+    postsControllerHardDelete: (id: number, params: RequestParams = {}) =>
+      this.request<void, any>({
+        path: `/posts/hard/${id}`,
+        method: 'DELETE',
+        secure: true,
+        ...params,
+      }),
+
+    /**
+     * @description 본인 게시글 수정용으로 id에 해당하는 게시글에 조인된 스티커 블록들의 값과 게시글 세부 데이터를 모두 가져온다.
+     *
+     * @tags 게시글 API
+     * @name PostsControllerFetchPost
+     * @summary [수정용] 게시글 및 스티커 상세 데이터 fetch
+     * @request GET:/posts/update/{id}
+     */
+    postsControllerFetchPost: (id: number, params: RequestParams = {}) =>
+      this.request<void, any>({
+        path: `/posts/update/${id}`,
+        method: 'GET',
+        ...params,
+      }),
+
+    /**
+     * @description id에 해당하는 게시글과 댓글을 가져온다. 조회수를 올린다.
+     *
+     * @tags 게시글 API
+     * @name PostsControllerFetchPostDetail
+     * @summary 게시글 디테일 뷰 fetch
+     * @request GET:/posts/detail/{id}
+     */
+    postsControllerFetchPostDetail: (id: number, params: RequestParams = {}) =>
+      this.request<void, any>({
+        path: `/posts/detail/${id}`,
+        method: 'GET',
+        ...params,
+      }),
+  };
+  likes = {
+    /**
+     * @description 로그인 된 유저가 {id}인 게시글에 좋아요를 토글한다.
+     *
+     * @tags 좋아요 API
+     * @name LikesControllerToggleLike
+     * @summary 좋아요 토글하기
+     * @request POST:/likes
+     * @secure
+     */
+    likesControllerToggleLike: (
+      data: ToggleLikeDto,
+      params: RequestParams = {},
+    ) =>
+      this.request<ToggleLikeResponseDto, void>({
+        path: `/likes`,
+        method: 'POST',
+        body: data,
+        secure: true,
+        type: ContentType.Json,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description {id}인 게시글에 좋아요를 누른 사람들을 확인한다.
+     *
+     * @tags 좋아요 API
+     * @name LikesControllerFetchLikes
+     * @summary 좋아요 누른 대상 조회하기
+     * @request GET:/likes/{id}
+     */
+    likesControllerFetchLikes: (id: number, params: RequestParams = {}) =>
+      this.request<FetchLikesResponseDto[], any>({
+        path: `/likes/${id}`,
+        method: 'GET',
+        format: 'json',
+        ...params,
+      }),
+  };
+  auth = {
+    /**
+     * @description [swagger 불가능, url 직접 이동] 카카오 서버에 로그인을 요청한다. 응답으로 도착한 kakaoId를 기반으로 jwt accessToken과 refreshToken을 클라이언트에게 쿠키로 전송한다
+     *
+     * @tags 인증 API
+     * @name AuthControllerKakaoLogin
+     * @summary 카카오 로그인
+     * @request GET:/auth/kakao
+     */
+    authControllerKakaoLogin: (params: RequestParams = {}) =>
+      this.request<any, void>({
+        path: `/auth/kakao`,
+        method: 'GET',
+        ...params,
+      }),
+
+    /**
+     * @description refreshToken을 기반으로 accessToken을 재발급한다.
+     *
+     * @tags 인증 API
+     * @name AuthControllerRefresh
+     * @summary accessToken refresh
+     * @request GET:/auth/refresh
+     * @secure
+     */
+    authControllerRefresh: (params: RequestParams = {}) =>
+      this.request<void, void>({
+        path: `/auth/refresh`,
+        method: 'GET',
+        secure: true,
+        ...params,
+      }),
+  };
+  neighbors = {
+    /**
+     * @description 로그인된 유저가 follow_id를 팔로우한다.
+     *
+     * @tags 이웃 API
+     * @name NeighborsControllerFollowUser
+     * @summary 이웃 추가하기
+     * @request POST:/neighbors/follow
+     * @secure
+     */
+    neighborsControllerFollowUser: (
+      data: FollowDto,
+      params: RequestParams = {},
+    ) =>
+      this.request<FollowUserDto, void>({
+        path: `/neighbors/follow`,
+        method: 'POST',
+        body: data,
+        secure: true,
+        type: ContentType.Json,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description 로그인된 유저가 follow_id를 언팔로우 한다.
+     *
+     * @tags 이웃 API
+     * @name NeighborsControllerUnfollowUser
+     * @summary 이웃 삭제하기
+     * @request POST:/neighbors/unfollow
+     * @secure
+     */
+    neighborsControllerUnfollowUser: (
+      data: FollowDto,
+      params: RequestParams = {},
+    ) =>
+      this.request<void, void>({
+        path: `/neighbors/unfollow`,
+        method: 'POST',
+        body: data,
+        secure: true,
+        type: ContentType.Json,
+        ...params,
+      }),
+
+    /**
+     * @description id의 팔로워 목록을 조회한다.
+     *
+     * @tags 이웃 API
+     * @name NeighborsControllerGetFollowers
+     * @summary 팔로워 목록 조회
+     * @request GET:/neighbors/followers/{id}
+     */
+    neighborsControllerGetFollowers: (id: number, params: RequestParams = {}) =>
+      this.request<FromUserResponseDto[], any>({
+        path: `/neighbors/followers/${id}`,
+        method: 'GET',
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description id의 팔로우 목록을 조회한다.
+     *
+     * @tags 이웃 API
+     * @name NeighborsControllerGetFollows
+     * @summary 팔로우 목록 조회
+     * @request GET:/neighbors/follows/{id}
+     */
+    neighborsControllerGetFollows: (id: number, params: RequestParams = {}) =>
+      this.request<ToUserResponseDto[], any>({
+        path: `/neighbors/follows/${id}`,
+        method: 'GET',
+        format: 'json',
+        ...params,
+      }),
+  };
+  postbg = {
+    /**
+     * No description
+     *
+     * @tags 내지 API
+     * @name PostBackgroundsControllerUploadImage
+     * @summary 내지 업로드
+     * @request POST:/postbg
+     */
+    postBackgroundsControllerUploadImage: (
+      data: ImageUploadDto,
+      params: RequestParams = {},
+    ) =>
+      this.request<ImageUploadResponseDto, any>({
+        path: `/postbg`,
+        method: 'POST',
+        body: data,
+        type: ContentType.FormData,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @tags 내지 API
+     * @name PostBackgroundsControllerFetchAll
+     * @summary 내지 모두 불러오기
+     * @request GET:/postbg
+     */
+    postBackgroundsControllerFetchAll: (params: RequestParams = {}) =>
+      this.request<PostBackground[], any>({
+        path: `/postbg`,
+        method: 'GET',
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @tags 내지 API
+     * @name PostBackgroundsControllerDelete
+     * @summary 내지 삭제하기
+     * @request DELETE:/postbg/{id}
+     */
+    postBackgroundsControllerDelete: (id: string, params: RequestParams = {}) =>
+      this.request<void, any>({
+        path: `/postbg/${id}`,
+        method: 'DELETE',
+        ...params,
+      }),
+  };
+  postcg = {
+    /**
+     * @description 로그인된 유저와 연결된 카테고리를 생성한다.
+     *
+     * @tags 카테고리 API
+     * @name PostCategoriesControllerCreatePostCategory
+     * @summary 카테고리 생성
+     * @request POST:/postcg
+     * @secure
+     */
+    postCategoriesControllerCreatePostCategory: (
+      data: CreatePostCategoryDto,
+      params: RequestParams = {},
+    ) =>
+      this.request<CreatePostCategoryResponseDto, any>({
+        path: `/postcg`,
+        method: 'POST',
+        body: data,
+        secure: true,
+        type: ContentType.Json,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description 로그인된 유저가 생성한 카테고리를 모두 불러온다
+     *
+     * @tags 카테고리 API
+     * @name PostCategoriesControllerFetchPostCategories
+     * @summary 유저의 모든 카테고리 불러오기
+     * @request GET:/postcg
+     * @secure
+     */
+    postCategoriesControllerFetchPostCategories: (params: RequestParams = {}) =>
+      this.request<PostCategory[], any>({
+        path: `/postcg`,
+        method: 'GET',
+        secure: true,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description 로그인된 유저의 카테고리 중 param:id와 일치하는 카테고리를 삭제한다
+     *
+     * @tags 카테고리 API
+     * @name PostCategoriesControllerDeletePostCategory
+     * @summary 유저의 지정 카테고리 삭제하기
+     * @request DELETE:/postcg/{id}
+     * @secure
+     */
+    postCategoriesControllerDeletePostCategory: (
+      id: string,
+      params: RequestParams = {},
+    ) =>
+      this.request<void, any>({
+        path: `/postcg/${id}`,
+        method: 'DELETE',
+        secure: true,
+        ...params,
+      }),
+  };
 }

--- a/types/__generated__.d.ts
+++ b/types/__generated__.d.ts
@@ -1,0 +1,367 @@
+/* eslint-disable */
+/* tslint:disable */
+/*
+ * ---------------------------------------------------------------
+ * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
+ * ##                                                           ##
+ * ## AUTHOR: acacode                                           ##
+ * ## SOURCE: https://github.com/acacode/swagger-typescript-api ##
+ * ---------------------------------------------------------------
+ */
+
+export interface CreateCommentInput {
+  /** 루트 게시글 아이디 */
+  postsId: number;
+  /** 댓글 내용 */
+  content: string;
+  /** [optional] 부모 댓글 id */
+  parentId?: number;
+  /** [optional] 수정 시 댓글 id */
+  id?: number;
+}
+
+export interface DeleteCommentDto {
+  /** 삭제하고자 하는 댓글 id */
+  id: number;
+}
+
+export interface UserResponseDto {
+  /** 카카오 id */
+  kakaoId: number;
+  /** 어드민 유저 여부 */
+  isAdmin: boolean;
+  /** 유저 이름 */
+  username: string;
+  /** 유저 설명 */
+  description: string;
+  /** 프로필 이미지 url */
+  profile_image: string;
+  /** 프로필 배경 이미지 url */
+  background_image: string;
+  /**
+   * 생성된 날짜
+   * @format date-time
+   */
+  date_created: string;
+  /**
+   * 삭제된 날짜
+   * @format date-time
+   */
+  date_deleted: string;
+}
+
+export interface PatchUserInput {
+  /**
+   * [optional] username 변경
+   * @example "optional"
+   */
+  username?: string;
+  /**
+   * [optional] description 변경
+   * @example "optional"
+   */
+  description?: string;
+}
+
+export interface ImageUploadDto {
+  /**
+   *  multipart/form-data 이미지
+   * @format binary
+   */
+  file: File;
+}
+
+export interface ImageUploadResponseDto {
+  /** 이미지가 저장된 url */
+  image_url: string;
+}
+
+export interface Sticker {
+  /** PK: A_I */
+  id: number;
+  /** 제작한 유저 fk */
+  userKakaoId: number;
+  /** 스티커 이미지 주소 */
+  image_url: string;
+  /** 블꾸 기본 제공 스티커 유무 */
+  isDefault: boolean;
+  /** 재사용 가능 유무 */
+  isReusable: boolean;
+}
+
+export interface StickerCategory {
+  /** PK: A_I_ */
+  id: number;
+  /** 카테고리 이름 */
+  name: string;
+}
+
+export interface MapCategoryDto {
+  /** 매핑 하고자 하는 스티커의 id */
+  stickerId: number;
+  /** 매핑 하고자 하는 카테고리의 id */
+  stickerCategoryId: number;
+}
+
+export interface CreateStickerBlockDto {
+  /** 참조하는 스티커의 아이디 */
+  stickerId: number;
+  /** 참조하는 포스트 아이디 */
+  postsId: number;
+  /** 스티커의 depth */
+  depth: number;
+  /** 스티커의 fill */
+  fill: string;
+  /** 스티커의 x좌표 */
+  x: string;
+  /** 스티커의 y좌표 */
+  y: string;
+  /** 스티커의 가로 폭 */
+  width: string;
+  /** 스티커의 세로 폭 */
+  height: string;
+}
+
+export interface CreatePostInput {
+  /** 포스트의 고유 아이디 */
+  id?: number;
+  /** 연결된 카테고리 fk */
+  postCategoryId?: string;
+  /** 연결된 내지 fk */
+  postBackgroundId?: string;
+  /** 제목(최대 100자) */
+  title: string;
+  /** 댓글 허용 여부(boolean) */
+  allow_comment?: boolean;
+  /** [공개 설정] PUBLIC: 전체공개, PROTECTED: 친구공개, PRIVATE: 비공개 */
+  scope?: 'PUBLIC' | 'PROTECTED' | 'PRIVATE';
+  /** 게시글 내용 */
+  content: string;
+  /** 게시글 캡쳐 이미지 url */
+  image_url: string;
+  /** 게시글 대표 이미지 url */
+  main_image_url: string;
+}
+
+export interface PublishPostDto {
+  /** 포스트의 고유 아이디 */
+  id: number;
+  /** 연결된 카테고리 fk */
+  postCategoryId: string;
+  /** 연결된 내지 fk */
+  postBackgroundId: string;
+  /** 작성한 유저 fk */
+  userKakaoId: number;
+  /** 제목(최대 100자) */
+  title: string;
+  /** 임시저장(false), 발행(true) */
+  isPublished: boolean;
+  /** 좋아요 카운트 */
+  like_count: number;
+  /** 조회수 카운트 */
+  view_count: number;
+  /** 댓글수 카운트 */
+  comment_count: number;
+  /** 댓글 허용 여부(boolean) */
+  allow_comment: boolean;
+  /** [공개 설정] PUBLIC: 전체공개, PROTECTED: 친구공개, PRIVATE: 비공개 */
+  scope: 'PUBLIC' | 'PROTECTED' | 'PRIVATE';
+  /**
+   * 생성된 날짜
+   * @format date-time
+   */
+  date_created: string;
+  /**
+   * 수정된 날짜
+   * @format date-time
+   */
+  date_updated: string;
+  /**
+   * soft delete column
+   * @format date-time
+   */
+  date_deleted: string;
+  /** 게시글 내용 */
+  content: string;
+  /** 게시글 캡쳐 이미지 url */
+  image_url: string;
+  /** 게시글 대표 이미지 url */
+  main_image_url: string;
+}
+
+export interface PublishPostInput {
+  /** 포스트의 고유 아이디 */
+  id?: number;
+  /** 연결된 카테고리 fk */
+  postCategoryId: string;
+  /** 연결된 내지 fk */
+  postBackgroundId: string;
+  /** 제목(최대 100자) */
+  title: string;
+  /** 댓글 허용 여부(boolean) */
+  allow_comment: boolean;
+  /** [공개 설정] PUBLIC: 전체공개, PROTECTED: 친구공개, PRIVATE: 비공개 */
+  scope: 'PUBLIC' | 'PROTECTED' | 'PRIVATE';
+  /** 게시글 내용 */
+  content: string;
+  /** 게시글 캡쳐 이미지 url */
+  image_url: string;
+  /** 게시글 대표 이미지 url */
+  main_image_url: string;
+}
+
+export interface PostCategory {
+  /** PK: uuid */
+  id: string;
+  /** 카테고리 이름 */
+  name: string;
+}
+
+export interface PostBackground {
+  /** PK: uuid */
+  id: string;
+  /** 이미지가 저장된 url */
+  image_url: string;
+}
+
+export interface PostResponseDto {
+  /** 임시저장 된 포스트의 아이디 */
+  id: number;
+  /** 작성자의 정보 */
+  user: UserResponseDto;
+  /** 지정할 카테고리의 아이디 */
+  postCategory: PostCategory;
+  /** 지정할 내지의 아이디 */
+  postBackground: PostBackground;
+  /** 제목 설정(최대 100자) */
+  title: string;
+  /** 댓글 허용 여부(boolean) */
+  allow_comment: boolean;
+  /** [공개 설정] PUBLIC: 전체공개, PROTECTED: 친구공개, PRIVATE: 비공개 */
+  scope: 'PUBLIC' | 'PROTECTED' | 'PRIVATE';
+}
+
+export interface PagePostResponseDto {
+  /** 한 페이지 당 아이템 갯수 */
+  pageSize: number;
+  /** 전체 아이템 갯수 */
+  totalCount: number;
+  /** 요청할 페이지 번호 */
+  totalPage: number;
+  /** 조회된 포스트 */
+  items: PostResponseDto[];
+}
+
+export interface ToggleLikeDto {
+  /** post_id */
+  id: number;
+}
+
+export interface ToggleLikeResponseDto {
+  /** 포스트의 고유 아이디 */
+  id: number;
+  /** 제목(최대 100자) */
+  title: string;
+  /** 임시저장(false), 발행(true) */
+  isPublished: boolean;
+  /** 좋아요 카운트 */
+  like_count: number;
+  /** 조회수 카운트 */
+  view_count: number;
+  /** 댓글 허용 여부(boolean) */
+  allow_comment: boolean;
+  /** [공개 설정] PUBLIC: 전체공개, PROTECTED: 친구공개, PRIVATE: 비공개 */
+  scope: 'PUBLIC' | 'PROTECTED' | 'PRIVATE';
+  /**
+   * 생성된 날짜
+   * @format date-time
+   */
+  date_created: string;
+  /**
+   * 수정된 날짜
+   * @format date-time
+   */
+  date_updated: string;
+  /**
+   * soft delete column
+   * @format date-time
+   */
+  date_deleted: string;
+}
+
+export interface User {
+  /** 카카오 id */
+  kakaoId: number;
+  /** crypted refresh token */
+  current_refresh_token: string;
+  /** 어드민 유저 여부 */
+  isAdmin: boolean;
+  /** 유저 이름 */
+  username: string;
+  /** 유저 설명 */
+  description: string;
+  /** 프로필 이미지 url */
+  profile_image: string;
+  /** 프로필 배경 이미지 url */
+  background_image: string;
+  /**
+   * 생성된 날짜
+   * @format date-time
+   */
+  date_created: string;
+  /**
+   * 삭제된 날짜
+   * @format date-time
+   */
+  date_deleted: string;
+}
+
+export interface FetchLikesResponseDto {
+  /** PK: uuid */
+  id: string;
+  /** 좋아요를 누른 유저 */
+  user: User;
+}
+
+export interface FollowDto {
+  /**
+   * 카카오 id
+   * @example 3388766789
+   */
+  follow_id: number;
+}
+
+export interface FollowUserDto {
+  /** PK: uuid */
+  id: string;
+  /** FK: kakaoId */
+  to_user: number;
+  /** FK: kakaoId */
+  from_user: number;
+}
+
+export interface FromUserResponseDto {
+  /** @example "b6993606-1992-427e-bf73-c3fc778a48ff" */
+  id: string;
+  from_user: UserResponseDto;
+}
+
+export interface ToUserResponseDto {
+  /** @example "b6993606-1992-427e-bf73-c3fc778a48ff" */
+  id: string;
+  to_user: UserResponseDto;
+}
+
+export interface CreatePostCategoryDto {
+  /** 카테고리 이름 */
+  name: string;
+}
+
+export interface CreatePostCategoryResponseDto {
+  /** PK: uuid */
+  id: string;
+  /** 카테고리 이름 */
+  name: string;
+  /** 유저 kakaoId */
+  user: number;
+}


### PR DESCRIPTION
## Summary

- swagger-typescript-api(이하 sta)를 설치 및 세팅하였습니다. 
- 백엔드의 Swagger를 바탕으로 타입을 자동생성하였습니다. 
- ReactQueryDevtools 및 기타 의존성을 설치하였습니다. 

## Describe your changes

sta를 사용하면 프론트에서 추가로 Dto, Entity 타입을 제작할 수고를 덜어줍니다. 
Ref: https://github.com/acacode/swagger-typescript-api
- 생성된 타입은 types/\_\_generated\_\_.d.ts 에서 확인 가능합니다. 
- 현재 pakcage.json의 sta 룰에서 백엔드 주소를 가려야 하는지 애매하여 일단 https://api.example.com 으로 설정해놓았습니다. **실 사용 시에는 실제 백엔드 주소로 변경해야 합니다.**

잘못 시행한 fix가 있어 알립니다.
- [fix(next.config.mjs): revise invalid rewrites - api -> proxy-api](https://github.com/DevKor-github/team-sprint-blccu-frontend/commit/6353b11baecce3920f6ad6afa9f636ef5f6a8804)는 하지 않아도 되는 fix 였습니다. (Vercel에 환경변수를 안 넣어서 생기는 문제였음)

설치한 의존성은 다음과 같습니다. 
- @tanstack/react-query-devtools
- swagger-typescript-api
- framer-motion
- date-fns
