### PR TITLE
feat: create ui components (ButtonRadioGroup, ResponsiveMasonry, etc.)

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -18,7 +18,7 @@ const preview: Preview = {
       viewports: {
         ...MINIMAL_VIEWPORTS,
       },
-      defaultViewport: 'mobile2',
+      defaultViewport: 'mobile1',
     },
   },
 };

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -20,6 +20,19 @@ const preview: Preview = {
       },
       defaultViewport: 'mobile1',
     },
+    options: {
+      storySort: {
+        includeNames: true,
+        order: [
+          'Components',
+          ['*', ['Playground', '*']],
+          'Unstable',
+          ['*', ['Playground', '*']],
+          'Experimental',
+          ['*', ['Playground', '*']],
+        ],
+      },
+    },
   },
 };
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -5,17 +5,17 @@
 @layer base {
   /* blccu design token (color) */
   :root {
-    --blccu-white: #ffffff;
-    --blccu-neutral-200: #eaeaea;
-    --blccu-neutral-400: #a6a6a6;
-    --blccu-neutral-600: #5b5b5b;
-    --blccu-neutral-800: #1a1a1a;
-    --blccu-black: #000000;
+    --blccu-white: 255 255 255; /* #ffffff */
+    --blccu-neutral-200: 234 234 234; /* #eaeaea */
+    --blccu-neutral-400: 166 166 166; /* #a6a6a6 */
+    --blccu-neutral-600: 91 91 91; /* #5b5b5b */
+    --blccu-neutral-800: 26 26 26; /* #1a1a1a */
+    --blccu-black: 0 0 0; /* #000000 */
 
-    --blccu-red: #ff4141;
+    --blccu-red: 255 65 65; /* #ff4141 */
 
     --blccu-input: var(--blccu-neutral-200);
-    --blccu-ring: #c0c0c0;
+    --blccu-ring: 192 192 192; /* #c0c0c0 */
 
     --blccu-background: var(--blccu-white);
     --blccu-foreground: var(--blccu-neutral-800);

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -9,7 +9,7 @@ import QueryProvider from '@/providers/query-provider';
 import './globals.css';
 
 const notoSansKr = Noto_Sans_KR({
-  weight: ['400', '500', '700', '900'],
+  weight: ['200', '400', '500', '700', '900'],
   subsets: ['latin'],
 });
 

--- a/components/ui-experimental/responsive-masonry/hooks/@toss/react/use-preserved-callback.ts
+++ b/components/ui-experimental/responsive-masonry/hooks/@toss/react/use-preserved-callback.ts
@@ -1,0 +1,21 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+/**
+ * @reference
+ * https://github.com/toss/slash/blob/main/packages/react/react/src/hooks/usePreservedCallback.ts
+ */
+const usePreservedCallback = <Callback extends (...args: any[]) => any>(
+  callback: Callback,
+) => {
+  const callbackRef = useRef<Callback>(callback);
+
+  useEffect(() => {
+    callbackRef.current = callback;
+  }, [callback]);
+
+  return useCallback((...args: any[]) => {
+    return callbackRef.current(...args);
+  }, []) as Callback;
+};
+
+export { usePreservedCallback };

--- a/components/ui-experimental/responsive-masonry/hooks/@toss/react/use-ref-effect.ts
+++ b/components/ui-experimental/responsive-masonry/hooks/@toss/react/use-ref-effect.ts
@@ -1,0 +1,47 @@
+import { type DependencyList, useCallback, useRef } from 'react';
+
+import { usePreservedCallback } from './use-preserved-callback';
+
+const noop = () => {};
+
+type EffectRef<E extends HTMLElement = HTMLElement> = (
+  element: E | null,
+) => void;
+
+type CleanupCallback = () => void;
+type RefCallback<E extends HTMLElement = HTMLElement> = (
+  element: E,
+) => CleanupCallback | void;
+
+/**
+ * @reference
+ * https://github.com/toss/slash/blob/main/packages/react/react/src/hooks/useResizeObserver.ts
+ */
+const useRefEffect = <E extends HTMLElement = HTMLElement>(
+  callback: RefCallback<E>,
+  deps: DependencyList,
+): EffectRef<E> => {
+  const preservedCallback = usePreservedCallback(callback);
+  const disposeRef = useRef<CleanupCallback>(noop);
+
+  const effect = useCallback(
+    (element: E | null) => {
+      disposeRef.current();
+      disposeRef.current = noop;
+
+      if (element != null) {
+        const cleanup = callback(element);
+
+        if (typeof cleanup === 'function') {
+          disposeRef.current = cleanup;
+        }
+      }
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [preservedCallback, ...deps],
+  );
+
+  return effect;
+};
+
+export { useRefEffect };

--- a/components/ui-experimental/responsive-masonry/hooks/@toss/react/use-resize-observer.ts
+++ b/components/ui-experimental/responsive-masonry/hooks/@toss/react/use-resize-observer.ts
@@ -1,0 +1,33 @@
+import { usePreservedCallback } from '@/components/ui-experimental/responsive-masonry/hooks/@toss/react/use-preserved-callback';
+import { useRefEffect } from '@/components/ui-experimental/responsive-masonry/hooks/@toss/react/use-ref-effect';
+
+type OnResize = (entry: ResizeObserverEntry) => void;
+
+/**
+ * @reference
+ * https://github.com/toss/slash/blob/main/packages/react/react/src/hooks/useResizeObserver.ts
+ */
+const useResizeObserver = <E extends HTMLElement = HTMLElement>(
+  onResize: OnResize,
+) => {
+  const resizeCallback = usePreservedCallback(onResize);
+  const ref = useRefEffect<E>(
+    (elem) => {
+      const observer = new ResizeObserver((entries) => {
+        if (entries[0] != null) {
+          resizeCallback(entries[0]);
+        }
+      });
+      observer.observe(elem);
+
+      return () => {
+        observer.unobserve(elem);
+      };
+    },
+    [resizeCallback],
+  );
+
+  return ref;
+};
+
+export { useResizeObserver };

--- a/components/ui-experimental/responsive-masonry/hooks/use-ref-element-list.ts
+++ b/components/ui-experimental/responsive-masonry/hooks/use-ref-element-list.ts
@@ -1,0 +1,35 @@
+import { useRef } from 'react';
+
+/**
+ * @reference
+ * https://ko.react.dev/learn/manipulating-the-dom-with-refs#how-to-manage-a-list-of-refs-using-a-ref-callback
+ */
+const useRefElementList = () => {
+  const ref = useRef<Map<number, HTMLElement>>();
+
+  const getMap = () => {
+    if (!ref.current) {
+      ref.current = new Map<number, HTMLElement>();
+    }
+
+    return ref.current;
+  };
+
+  const getRefElementList = () => {
+    return Array.from(getMap().values());
+  };
+
+  const manageElement = (index: number, element: HTMLElement | null) => {
+    const map = getMap();
+
+    if (element !== null) {
+      map.set(index, element);
+    } else {
+      map.delete(index);
+    }
+  };
+
+  return { getRefElementList, manageElement };
+};
+
+export { useRefElementList };

--- a/components/ui-experimental/responsive-masonry/hooks/use-responsive-masonry.ts
+++ b/components/ui-experimental/responsive-masonry/hooks/use-responsive-masonry.ts
@@ -1,0 +1,48 @@
+import { useState } from 'react';
+
+import { useResizeObserver } from '@/components/ui-experimental/responsive-masonry/hooks/@toss/react/use-resize-observer';
+import { type ResponsiveMasonryBreakpoint } from '@/components/ui-experimental/responsive-masonry/responsive-masonry__experimental';
+
+type GetColumnsParams = {
+  refWidth: number;
+  breakpoints: ResponsiveMasonryBreakpoint[];
+};
+
+const getColumns = ({ refWidth, breakpoints }: GetColumnsParams) => {
+  const reverseSortedBreakpoints = breakpoints
+    .slice()
+    .sort((a, b) => b.width - a.width);
+
+  for (const breakpoint of reverseSortedBreakpoints) {
+    if (refWidth >= breakpoint.width) {
+      return breakpoint.columns;
+    }
+  }
+
+  // when smallest width in breakpoints is not 0
+  return reverseSortedBreakpoints[reverseSortedBreakpoints.length - 1].columns;
+};
+
+type UseResponsiveMansoryParams = {
+  breakpoints: ResponsiveMasonryBreakpoint[];
+};
+
+const useResponsiveMasonry = ({ breakpoints }: UseResponsiveMansoryParams) => {
+  const [refWidth, setRefWidth] = useState(0);
+  const [columns, setColumns] = useState(1);
+
+  const onResize = (entry: ResizeObserverEntry) => {
+    const { width: refWidth } = entry.contentRect;
+
+    const columns = getColumns({ refWidth, breakpoints });
+
+    setRefWidth(refWidth);
+    setColumns(columns);
+  };
+
+  const ref = useResizeObserver<HTMLDivElement>(onResize);
+
+  return { columns, ref, refWidth };
+};
+
+export { useResponsiveMasonry };

--- a/components/ui-experimental/responsive-masonry/responsive-masonry__experimental.stories.tsx
+++ b/components/ui-experimental/responsive-masonry/responsive-masonry__experimental.stories.tsx
@@ -1,0 +1,134 @@
+import { type Meta, type StoryObj } from '@storybook/react';
+
+import {
+  MasonryItem,
+  ResponsiveMasonry__Experimental,
+} from '@/components/ui-experimental/responsive-masonry/responsive-masonry__experimental';
+import { AutoHeightImage } from '@/components/ui-unstable/auto-height-image';
+
+const meta: Meta<typeof ResponsiveMasonry__Experimental> = {
+  title: 'Experimental/ResponsiveMasonry',
+  component: ResponsiveMasonry__Experimental,
+  argTypes: {
+    breakpoints: {
+      control: {
+        type: 'object',
+      },
+    },
+    gap: {
+      control: {
+        type: 'number',
+      },
+    },
+  },
+  parameters: {
+    controls: {
+      exclude: ['children'],
+    },
+  },
+};
+
+type Story = StoryObj<typeof ResponsiveMasonry__Experimental>;
+
+const examplePhotos = [
+  'https://images.unsplash.com/photo-1646187043863-d34d6f85ae93?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3wxMTc3M3wwfDF8c2VhcmNofDV8fCVFQyVBMCU5QyVFQyVBMyVCQyVFQiU4RiU4NHxlbnwwfHx8fDE3MTI4NTY2OTd8MA&ixlib=rb-4.0.3&q=80&w=2000',
+  'https://media.licdn.com/dms/image/D5612AQFZIgb14PcZcQ/article-cover_image-shrink_720_1280/0/1712832990937?e=1718841600&v=beta&t=rkC9GhFLLCKpSC_EGubZxcYQfFYfhSDB7cz4_x1UnN0',
+  'https://www.lgcns.com/wp-content/uploads/2021/11/276D393458F07A4F04.png',
+  'https://thumb.ac-illust.com/37/37405b48206e100357550676fd124a8f_t.jpeg',
+  'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSYyOevSjb-FLCa7OVwOcPAp7cj4w2gNm2F2K9koBr4uQ&s',
+  'https://img.hankyung.com/photo/202009/AA.23690748.1.jpg',
+  'https://blog.altair.co.kr/wp-content/uploads/2021/06/large-895567_1920-1024x577.jpg',
+  'https://thumb.ac-illust.com/37/37405b48206e100357550676fd124a8f_t.jpeg',
+  'https://media.licdn.com/dms/image/D5612AQFZIgb14PcZcQ/article-cover_image-shrink_720_1280/0/1712832990937?e=1718841600&v=beta&t=rkC9GhFLLCKpSC_EGubZxcYQfFYfhSDB7cz4_x1UnN0',
+  'https://www.lgcns.com/wp-content/uploads/2021/11/276D393458F07A4F04.png',
+  'https://png.pngtree.com/thumb_back/fh260/background/20201012/pngtree-rainy-sky-background-image_410908.jpg',
+  'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSRvFR_pTwpwLHPvcVSfpN1kdh76k78qi01ZqsU3M7CNw&s',
+  'https://img.hankyung.com/photo/202009/AA.23690748.1.jpg',
+  'https://blog.altair.co.kr/wp-content/uploads/2021/06/large-895567_1920-1024x577.jpg',
+  'https://images.unsplash.com/photo-1646187043863-d34d6f85ae93?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3wxMTc3M3wwfDF8c2VhcmNofDV8fCVFQyVBMCU5QyVFQyVBMyVCQyVFQiU4RiU4NHxlbnwwfHx8fDE3MTI4NTY2OTd8MA&ixlib=rb-4.0.3&q=80&w=2000',
+  'https://media.licdn.com/dms/image/D5612AQFZIgb14PcZcQ/article-cover_image-shrink_720_1280/0/1712832990937?e=1718841600&v=beta&t=rkC9GhFLLCKpSC_EGubZxcYQfFYfhSDB7cz4_x1UnN0',
+  'https://www.lgcns.com/wp-content/uploads/2021/11/276D393458F07A4F04.png',
+  'https://png.pngtree.com/thumb_back/fh260/background/20201012/pngtree-rainy-sky-background-image_410908.jpg',
+  'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSRvFR_pTwpwLHPvcVSfpN1kdh76k78qi01ZqsU3M7CNw&s',
+  'https://thumb.ac-illust.com/37/37405b48206e100357550676fd124a8f_t.jpeg',
+  'https://blog.altair.co.kr/wp-content/uploads/2021/06/large-895567_1920-1024x577.jpg',
+  'https://images.unsplash.com/photo-1646187043863-d34d6f85ae93?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3wxMTc3M3wwfDF8c2VhcmNofDV8fCVFQyVBMCU5QyVFQyVBMyVCQyVFQiU4RiU4NHxlbnwwfHx8fDE3MTI4NTY2OTd8MA&ixlib=rb-4.0.3&q=80&w=2000',
+  'https://media.licdn.com/dms/image/D5612AQFZIgb14PcZcQ/article-cover_image-shrink_720_1280/0/1712832990937?e=1718841600&v=beta&t=rkC9GhFLLCKpSC_EGubZxcYQfFYfhSDB7cz4_x1UnN0',
+  'https://www.lgcns.com/wp-content/uploads/2021/11/276D393458F07A4F04.png',
+  'https://png.pngtree.com/thumb_back/fh260/background/20201012/pngtree-rainy-sky-background-image_410908.jpg',
+  'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSRvFR_pTwpwLHPvcVSfpN1kdh76k78qi01ZqsU3M7CNw&s',
+  'https://img.hankyung.com/photo/202009/AA.23690748.1.jpg',
+  'https://blog.altair.co.kr/wp-content/uploads/2021/06/large-895567_1920-1024x577.jpg',
+  'https://images.unsplash.com/photo-1646187043863-d34d6f85ae93?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3wxMTc3M3wwfDF8c2VhcmNofDV8fCVFQyVBMCU5QyVFQyVBMyVCQyVFQiU4RiU4NHxlbnwwfHx8fDE3MTI4NTY2OTd8MA&ixlib=rb-4.0.3&q=80&w=2000',
+  'https://media.licdn.com/dms/image/D5612AQFZIgb14PcZcQ/article-cover_image-shrink_720_1280/0/1712832990937?e=1718841600&v=beta&t=rkC9GhFLLCKpSC_EGubZxcYQfFYfhSDB7cz4_x1UnN0',
+  'https://www.lgcns.com/wp-content/uploads/2021/11/276D393458F07A4F04.png',
+  'https://png.pngtree.com/thumb_back/fh260/background/20201012/pngtree-rainy-sky-background-image_410908.jpg',
+  'https://thumb.ac-illust.com/37/37405b48206e100357550676fd124a8f_t.jpeg',
+  'https://img.hankyung.com/photo/202009/AA.23690748.1.jpg',
+  'https://thumb.ac-illust.com/37/37405b48206e100357550676fd124a8f_t.jpeg',
+  'https://images.unsplash.com/photo-1646187043863-d34d6f85ae93?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3wxMTc3M3wwfDF8c2VhcmNofDV8fCVFQyVBMCU5QyVFQyVBMyVCQyVFQiU4RiU4NHxlbnwwfHx8fDE3MTI4NTY2OTd8MA&ixlib=rb-4.0.3&q=80&w=2000',
+  'https://media.licdn.com/dms/image/D5612AQFZIgb14PcZcQ/article-cover_image-shrink_720_1280/0/1712832990937?e=1718841600&v=beta&t=rkC9GhFLLCKpSC_EGubZxcYQfFYfhSDB7cz4_x1UnN0',
+  'https://www.lgcns.com/wp-content/uploads/2021/11/276D393458F07A4F04.png',
+  'https://png.pngtree.com/thumb_back/fh260/background/20201012/pngtree-rainy-sky-background-image_410908.jpg',
+  'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSRvFR_pTwpwLHPvcVSfpN1kdh76k78qi01ZqsU3M7CNw&s',
+  'https://img.hankyung.com/photo/202009/AA.23690748.1.jpg',
+  'https://blog.altair.co.kr/wp-content/uploads/2021/06/large-895567_1920-1024x577.jpg',
+];
+
+const Playground: Story = {
+  args: {
+    breakpoints: [
+      { width: 0, columns: 1 },
+      { width: 240, columns: 2 },
+      { width: 360, columns: 3 },
+    ],
+    gap: 12,
+    children: Array(50)
+      .fill(null)
+      .map((_, index) => {
+        const aspectRatio = Math.random() * 0.5 + 0.5;
+
+        return (
+          <MasonryItem key={index}>
+            <div className="flex flex-col gap-2">
+              <div
+                className="flex items-center justify-center bg-gray-200"
+                style={{
+                  aspectRatio,
+                }}
+              >
+                {index}
+              </div>
+              <div className="flex items-center gap-2">
+                <div className="h-6 w-6 rounded-full bg-gray-200" />
+                <div className="h-6 w-6 rounded-full bg-gray-200" />
+                <div className="h-6 w-6 rounded-full bg-gray-200" />
+              </div>
+            </div>
+          </MasonryItem>
+        );
+      }),
+  },
+};
+
+const Example: Story = {
+  render: () => (
+    <ResponsiveMasonry__Experimental
+      breakpoints={[
+        { width: 0, columns: 1 },
+        { width: 240, columns: 2 },
+        { width: 360, columns: 3 },
+      ]}
+      gap={8}
+    >
+      {examplePhotos.map((photo, index) => (
+        <MasonryItem key={index}>
+          <AutoHeightImage src={photo} alt="photo" className="rounded-md" />
+        </MasonryItem>
+      ))}
+    </ResponsiveMasonry__Experimental>
+  ),
+};
+
+export { Example, Playground };
+export default meta;

--- a/components/ui-experimental/responsive-masonry/responsive-masonry__experimental.tsx
+++ b/components/ui-experimental/responsive-masonry/responsive-masonry__experimental.tsx
@@ -1,0 +1,130 @@
+'use client';
+
+import {
+  type PropsWithChildren,
+  createContext,
+  forwardRef,
+  useContext,
+} from 'react';
+
+import { useRefElementList } from '@/components/ui-experimental/responsive-masonry/hooks/use-ref-element-list';
+import { useResponsiveMasonry } from '@/components/ui-experimental/responsive-masonry/hooks/use-responsive-masonry';
+
+const MasonryItem = ({ children }: PropsWithChildren) => {
+  const context = useContext(MasonryContext);
+
+  if (context === null) {
+    throw new Error('MasonryItem must be used inside Masonry');
+  }
+
+  const index = context.autoIncrementIndex++;
+
+  return (
+    <div
+      ref={(element) => context.manageElement(index, element)}
+      className="absolute left-0 top-0"
+    >
+      {children}
+    </div>
+  );
+};
+
+type UpdateElementPositionsParams = {
+  columns: number;
+  refWidth: number;
+  getRefElementList: () => HTMLElement[];
+  gap: number;
+};
+
+const updateElementPositions = ({
+  columns,
+  refWidth,
+  getRefElementList,
+  gap,
+}: UpdateElementPositionsParams) => {
+  const widthPerColumnIncludingGap = refWidth / columns;
+  const widthPerColumn = widthPerColumnIncludingGap - gap;
+
+  const heights = Array(columns).fill(0);
+
+  const elements = getRefElementList();
+
+  elements.forEach((element) => {
+    element.style.width = `${widthPerColumn}px`;
+
+    const column = heights.indexOf(Math.min(...heights));
+
+    const x = column * widthPerColumnIncludingGap;
+    const y = heights[column];
+    heights[column] += element.clientHeight + gap;
+
+    element.style.transform = `translateX(${x}px) translateY(${y}px`;
+  });
+};
+
+type MasonryContextProps = {
+  autoIncrementIndex: number;
+  manageElement: (index: number, element: HTMLElement | null) => void;
+};
+
+const MasonryContext = createContext<MasonryContextProps | null>(null);
+
+type MasonryProps = {
+  columns: number;
+  refWidth: number;
+  gap: number;
+} & PropsWithChildren;
+
+const Masonry = forwardRef<HTMLDivElement, MasonryProps>(
+  ({ columns, refWidth, gap, children }, ref) => {
+    const { getRefElementList, manageElement } = useRefElementList();
+
+    updateElementPositions({
+      columns,
+      refWidth,
+      getRefElementList,
+      gap,
+    });
+
+    const contextValue = { autoIncrementIndex: 0, manageElement };
+
+    return (
+      <div className="relative" ref={ref}>
+        <MasonryContext.Provider value={contextValue}>
+          {children}
+        </MasonryContext.Provider>
+      </div>
+    );
+  },
+);
+Masonry.displayName = 'Masonry';
+
+type ResponsiveMasonryBreakpoint = {
+  width: number;
+  columns: number;
+};
+
+type ResponsiveMasonryProps = {
+  breakpoints: ResponsiveMasonryBreakpoint[];
+  gap: number;
+} & PropsWithChildren;
+
+const ResponsiveMasonry__Experimental = ({
+  breakpoints,
+  gap,
+  children,
+}: ResponsiveMasonryProps) => {
+  const { columns, ref, refWidth } = useResponsiveMasonry({ breakpoints });
+
+  return (
+    <Masonry ref={ref} refWidth={refWidth} columns={columns} gap={gap}>
+      {children}
+    </Masonry>
+  );
+};
+
+export {
+  MasonryItem,
+  ResponsiveMasonry__Experimental,
+  type ResponsiveMasonryBreakpoint,
+};

--- a/components/ui-unstable/auto-height-image.tsx
+++ b/components/ui-unstable/auto-height-image.tsx
@@ -1,0 +1,21 @@
+import Image, { type ImageProps } from 'next/image';
+
+import { cn } from '@/lib/utils';
+
+/**
+ * @reference
+ * https://stackoverflow.com/questions/69230343/nextjs-image-component-with-fixed-witdth-and-auto-height
+ */
+const AutoHeightImage = ({ className, ...props }: ImageProps) => {
+  return (
+    <Image
+      width="0"
+      height="0"
+      sizes="100vw"
+      className={cn('w-full object-cover', className)}
+      {...props}
+    />
+  );
+};
+
+export { AutoHeightImage };

--- a/components/ui-unstable/bottom-action-sheet.stories.tsx
+++ b/components/ui-unstable/bottom-action-sheet.stories.tsx
@@ -1,0 +1,53 @@
+import { type Meta, type StoryObj } from '@storybook/react';
+import { ChevronLeft, Pen } from 'lucide-react';
+
+import {
+  BottomActionSheet,
+  BottomActionSheetContent,
+  BottomActionSheetGroup,
+  BottomActionSheetItem,
+  BottomActionSheetSeparator,
+  BottomActionSheetTrigger,
+} from '@/components/ui-unstable/bottom-action-sheet';
+import { IconButton } from '@/components/ui/icon-button';
+
+const meta: Meta<typeof BottomActionSheet> = {
+  title: 'Unstable/BottomActionSheet',
+  component: BottomActionSheet,
+};
+
+type Story = StoryObj<typeof BottomActionSheet>;
+
+const Example: Story = {
+  render: () => (
+    <div className="flex items-center justify-between">
+      <IconButton>
+        <ChevronLeft className="h-6 w-6" />
+      </IconButton>
+      <p className="text-lg font-bold">카테고리</p>
+      <BottomActionSheet>
+        <BottomActionSheetTrigger asChild>
+          <IconButton>
+            <Pen className="h-5 w-5" />
+          </IconButton>
+        </BottomActionSheetTrigger>
+        <BottomActionSheetContent>
+          <BottomActionSheetGroup>
+            <BottomActionSheetItem>수정하기</BottomActionSheetItem>
+            <BottomActionSheetSeparator />
+            <BottomActionSheetItem className="text-blccu-red">
+              삭제하기
+            </BottomActionSheetItem>
+            <BottomActionSheetSeparator />
+          </BottomActionSheetGroup>
+          <BottomActionSheetGroup>
+            <BottomActionSheetItem>취소하기</BottomActionSheetItem>
+          </BottomActionSheetGroup>
+        </BottomActionSheetContent>
+      </BottomActionSheet>
+    </div>
+  ),
+};
+
+export { Example };
+export default meta;

--- a/components/ui-unstable/bottom-action-sheet.tsx
+++ b/components/ui-unstable/bottom-action-sheet.tsx
@@ -1,0 +1,114 @@
+import * as React from 'react';
+
+import * as SheetPrimitive from '@radix-ui/react-dialog';
+import { type VariantProps, cva } from 'class-variance-authority';
+
+import { cn } from '@/lib/utils';
+
+const BottomActionSheet = SheetPrimitive.Root;
+
+const BottomActionSheetTrigger = SheetPrimitive.Trigger;
+
+const BottomActionSheetClose = SheetPrimitive.Close;
+
+const BottomActionSheetPortal = SheetPrimitive.Portal;
+
+const BottomActionSheetOverlay = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Overlay
+    className={cn(
+      'fixed inset-0 z-50 bg-blccu-black/40',
+      'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      className,
+    )}
+    {...props}
+    ref={ref}
+  />
+));
+BottomActionSheetOverlay.displayName = SheetPrimitive.Overlay.displayName;
+
+const bottomActionSheetVariants = cva(
+  cn(
+    'fixed z-50 gap-4 mx-6 mb-6 shadow-lg transition',
+    'ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500',
+    'flex flex-col gap-2',
+  ),
+  {
+    variants: {
+      side: {
+        bottom: cn(
+          'inset-x-0 bottom-0',
+          'data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom',
+        ),
+      },
+    },
+    defaultVariants: {
+      side: 'bottom',
+    },
+  },
+);
+
+interface BottomActionSheetContentProps
+  extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
+    VariantProps<typeof bottomActionSheetVariants> {}
+
+const BottomActionSheetContent = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Content>,
+  BottomActionSheetContentProps
+>(({ className, children, ...props }, ref) => (
+  <BottomActionSheetPortal>
+    <BottomActionSheetOverlay />
+    <SheetPrimitive.Content
+      ref={ref}
+      className={cn(bottomActionSheetVariants(), className)}
+      {...props}
+    >
+      {children}
+    </SheetPrimitive.Content>
+  </BottomActionSheetPortal>
+));
+BottomActionSheetContent.displayName = SheetPrimitive.Content.displayName;
+
+const BottomActionSheetGroup = ({ children }: React.PropsWithChildren) => {
+  return (
+    <div className="w-full rounded-lg bg-blccu-neutral-200">{children}</div>
+  );
+};
+
+type BottomActionSheetItemProps = {
+  className?: string;
+} & React.PropsWithChildren;
+
+const BottomActionSheetItem = ({
+  children,
+  className,
+}: BottomActionSheetItemProps) => {
+  return (
+    <BottomActionSheetClose asChild>
+      <div
+        className={cn(
+          'cursor-pointer py-3 text-center text-sm text-blccu-neutral-600',
+          className,
+        )}
+      >
+        {children}
+      </div>
+    </BottomActionSheetClose>
+  );
+};
+
+const BottomActionSheetSeparator = () => {
+  return <div className="h-[0.5px] bg-blccu-black/40" />;
+};
+
+export {
+  BottomActionSheet,
+  BottomActionSheetClose,
+  BottomActionSheetContent,
+  BottomActionSheetGroup,
+  BottomActionSheetItem,
+  BottomActionSheetSeparator,
+  BottomActionSheetTrigger,
+};

--- a/components/ui-unstable/button-radio-group.stories.tsx
+++ b/components/ui-unstable/button-radio-group.stories.tsx
@@ -12,27 +12,12 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 
-const meta: Meta<typeof Select> = {
-  title: 'Components/Select',
-  component: Select,
+const meta: Meta<typeof ButtonRadioGroup> = {
+  title: 'Unstable/ButtonRadioGroup',
+  component: ButtonRadioGroup,
 };
 
-type Story = StoryObj<typeof Select>;
-
-const Disabled: Story = {
-  render: () => (
-    <Select>
-      <SelectTrigger className="w-full" disabled>
-        <SelectValue placeholder="카테고리를 선택하세요." />
-      </SelectTrigger>
-      <SelectContent>
-        <SelectItem value="none">선택 안함</SelectItem>
-        <SelectItem value="diary">일기</SelectItem>
-        <SelectItem value="review">리뷰</SelectItem>
-      </SelectContent>
-    </Select>
-  ),
-};
+type Story = StoryObj<typeof ButtonRadioGroup>;
 
 const Example: Story = {
   render: () => (
@@ -79,5 +64,5 @@ const Example: Story = {
   ),
 };
 
-export { Disabled, Example };
+export { Example };
 export default meta;

--- a/components/ui-unstable/button-radio-group.tsx
+++ b/components/ui-unstable/button-radio-group.tsx
@@ -1,0 +1,88 @@
+import {
+  type MouseEventHandler,
+  type ReactNode,
+  createContext,
+  useContext,
+  useState,
+} from 'react';
+
+import { Button } from '@/components/ui/button';
+
+type ButtonRadioGroupContextProps = {
+  value: string;
+  onClick: MouseEventHandler<HTMLButtonElement>;
+};
+
+const ButtonRadioGroupContext =
+  createContext<ButtonRadioGroupContextProps | null>(null);
+
+type ButtonRadioGroupProps = {
+  children: ReactNode;
+  defaultValue: string;
+  className?: string;
+  onValueChange?: (value: string) => void;
+};
+
+const ButtonRadioGroup = ({
+  children,
+  defaultValue,
+  className,
+  onValueChange,
+}: ButtonRadioGroupProps) => {
+  const [value, setValue] = useState(defaultValue);
+
+  const handleClick: MouseEventHandler<HTMLButtonElement> = (event) => {
+    const { value } = event.currentTarget;
+
+    if (onValueChange !== undefined) {
+      onValueChange(value);
+    }
+
+    setValue(value);
+  };
+
+  const contextValue = { value, onClick: handleClick };
+
+  return (
+    <div className={className}>
+      <ButtonRadioGroupContext.Provider value={contextValue}>
+        {children}
+      </ButtonRadioGroupContext.Provider>
+    </div>
+  );
+};
+
+type ButtonRadioGroupItemProps = {
+  children: ReactNode;
+  value: string;
+  className?: string;
+};
+
+const ButtonRadioGroupItem = ({
+  children,
+  value,
+  className,
+}: ButtonRadioGroupItemProps) => {
+  const context = useContext(ButtonRadioGroupContext);
+
+  if (context === null) {
+    throw new Error(
+      'ButtonRadioGroupItem must be used inside ButtonRadioGroup',
+    );
+  }
+
+  const variant = context.value === value ? 'default' : 'secondary';
+
+  return (
+    <Button
+      variant={variant}
+      value={value}
+      onClick={context.onClick}
+      className={className}
+    >
+      {children}
+    </Button>
+  );
+};
+
+export { ButtonRadioGroup, ButtonRadioGroupItem };

--- a/components/ui-unstable/horizontal-scrollable-post-card.stories.tsx
+++ b/components/ui-unstable/horizontal-scrollable-post-card.stories.tsx
@@ -1,0 +1,87 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { HorizontalScrollablePostCard } from '@/components/ui-unstable/horizontal-scrollable-post-card';
+import { ScrollArea, ScrollBar } from '@/components/ui/scroll-area';
+
+const meta: Meta<typeof HorizontalScrollablePostCard> = {
+  title: 'Unstable/HorizontalScrollablePostCard',
+  component: HorizontalScrollablePostCard,
+  argTypes: {
+    username: {
+      control: {
+        type: 'text',
+      },
+    },
+    avatar: {
+      control: {
+        type: 'text',
+      },
+    },
+    title: {
+      control: {
+        type: 'text',
+      },
+    },
+    thumbnail: {
+      control: {
+        type: 'text',
+      },
+    },
+  },
+};
+
+type Story = StoryObj<typeof HorizontalScrollablePostCard>;
+
+const Playground: Story = {
+  args: {
+    username: 'purple LUV',
+    avatar:
+      'https://contents.lotteon.com/itemimage/_v131313/LO/20/52/07/65/85/_2/05/20/76/58/7/LO2052076585_2052076587_1.jpg/dims/resizef/720X720',
+    title: '여름, 복숭아',
+    thumbnail:
+      'https://lh5.googleusercontent.com/proxy/eIxx4QbdjRmWk5ge_74jLPGNQsgqG34XliuiqM16BcBd-W-WXUBq4o8F7L6LRW9iqLF0Dw1Pm52w_0CisqPBbejh6ke810ccuZhorcglefFJac8wpYCJO-CRNNfBBKxCxhu3ZygU',
+  },
+};
+
+const exampleData = [
+  {
+    username: 'purple LUV',
+    avatar:
+      'https://contents.lotteon.com/itemimage/_v131313/LO/20/52/07/65/85/_2/05/20/76/58/7/LO2052076585_2052076587_1.jpg/dims/resizef/720X720',
+    title: '여름, 복숭아',
+    thumbnail:
+      'https://lh5.googleusercontent.com/proxy/eIxx4QbdjRmWk5ge_74jLPGNQsgqG34XliuiqM16BcBd-W-WXUBq4o8F7L6LRW9iqLF0Dw1Pm52w_0CisqPBbejh6ke810ccuZhorcglefFJac8wpYCJO-CRNNfBBKxCxhu3ZygU',
+  },
+  {
+    username: 'J soo',
+    avatar:
+      'https://entertainimg.kbsmedia.co.kr/cms/uploads/PERSON_20240206075441_1b54f931528a9d36c98db236a5e19d74.jpg',
+    title: '영화 추천해요!',
+    thumbnail:
+      'https://d2k6w3n3qf94c4.cloudfront.net/media/test/main_image/%E1%84%92%E1%85%A2%E1%84%85%E1%85%B5%E1%84%91%E1%85%A9%E1%84%90%E1%85%A5_%E1%84%87%E1%85%B5%E1%84%92%E1%85%A1%E1%84%8B%E1%85%B5%E1%86%AB%E1%84%83%E1%85%B3_%E1%84%89%E1%85%B3%E1%84%90%E1%85%A9%E1%84%85%E1%85%B5__%E1%84%89%E1%85%B3%E1%86%AF%E1%84%91%E1%85%B3%E1%86%AB%E1%84%8C%E1%85%B5%E1%86%AB%E1%84%89%E1%85%B5%E1%86%AF.jpeg',
+  },
+  {
+    username: '유파랑',
+    avatar:
+      'https://www.altius-group.com.au/hs-fs/hubfs/website-2023/services/people-and-employee-services/Altius_Group_People_and_Employee_Services_Employee_Assistance_Program%20.webp?width=800&height=800&name=Altius_Group_People_and_Employee_Services_Employee_Assistance_Program%20.webp',
+    title: '비오는 날이 좋아 ☂',
+    thumbnail:
+      'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSBMQ4MLWDwor_EWB2696OajKDKa8Zff1_XAbceJjRduw&s',
+  },
+];
+
+const Example: Story = {
+  render: () => (
+    <ScrollArea>
+      <div className="flex gap-3 pb-4">
+        {exampleData.map((data, index) => (
+          <HorizontalScrollablePostCard key={index} {...data} />
+        ))}
+      </div>
+      <ScrollBar orientation="horizontal" />
+    </ScrollArea>
+  ),
+};
+
+export { Example, Playground };
+export default meta;

--- a/components/ui-unstable/horizontal-scrollable-post-card.tsx
+++ b/components/ui-unstable/horizontal-scrollable-post-card.tsx
@@ -1,0 +1,43 @@
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { cn } from '@/lib/utils';
+
+type HorizontalScrollablePostCardProps = {
+  username: string;
+  avatar: string;
+  title: string;
+  thumbnail: string;
+};
+
+const HorizontalScrollablePostCard = ({
+  username,
+  avatar,
+  title,
+  thumbnail,
+}: HorizontalScrollablePostCardProps) => {
+  return (
+    <figure
+      className={cn(
+        'relative flex h-52 w-36 flex-col rounded-lg bg-cover bg-center shadow-lg transition',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blccu-ring',
+      )}
+      style={{
+        backgroundImage: `url(${thumbnail})`,
+      }}
+    >
+      <div className="absolute bottom-0 flex w-full items-center gap-2 rounded-b-lg bg-blccu-white px-2 py-3">
+        <Avatar size="xs">
+          <AvatarImage src={avatar} alt="avatar" />
+          <AvatarFallback className="bg-blccu-neutral-400" />
+        </Avatar>
+        <div className="flex w-full flex-col">
+          <h3 className="line-clamp-1 text-sm">{title}</h3>
+          <p className="line-clamp-1 text-2xs font-light text-blccu-neutral-600">
+            {username}
+          </p>
+        </div>
+      </div>
+    </figure>
+  );
+};
+
+export { HorizontalScrollablePostCard };

--- a/components/ui-unstable/stacked-post-card.stories.tsx
+++ b/components/ui-unstable/stacked-post-card.stories.tsx
@@ -1,0 +1,129 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { StackedPostCard } from '@/components/ui-unstable/stacked-post-card';
+
+const meta: Meta<typeof StackedPostCard> = {
+  title: 'Unstable/StackedPostCard',
+  component: StackedPostCard,
+  argTypes: {
+    username: {
+      control: {
+        type: 'text',
+      },
+    },
+    title: {
+      control: {
+        type: 'text',
+      },
+    },
+    description: {
+      control: {
+        type: 'text',
+      },
+    },
+    thumbnail: {
+      control: {
+        type: 'text',
+      },
+    },
+    date: {
+      control: {
+        type: 'date',
+      },
+    },
+  },
+};
+
+type Story = StoryObj<typeof StackedPostCard>;
+
+const Playground: Story = {
+  args: {
+    username: '유파랑',
+    title: '비오는 날이 좋아 ☂',
+    description:
+      '벚꽃이 떨어지는게 아쉽긴 해도 비오는 날은 역시 좋은 것 같아요! 톡톡 떨어지는 소리가 마음을 편안하게 해주는 것 같아요. 여러분은 어떤 날씨를 좋아하시나요?',
+    thumbnail:
+      'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSBMQ4MLWDwor_EWB2696OajKDKa8Zff1_XAbceJjRduw&s',
+    date: new Date(2024, 2, 18),
+  },
+};
+
+const exampleData = [
+  {
+    username: '유파랑',
+    title: '비오는 날이 좋아 ☂',
+    description:
+      '벚꽃이 떨어지는게 아쉽긴 해도 비오는 날은 역시 좋은 것 같아요! 톡톡 떨어지는 소리가 마음을 편안하게 해주는 것 같아요. 여러분은 어떤 날씨를 좋아하시나요?',
+    thumbnail:
+      'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSBMQ4MLWDwor_EWB2696OajKDKa8Zff1_XAbceJjRduw&s',
+    date: new Date(2024, 2, 18),
+  },
+  {
+    username: '이야옹',
+    title: '우리집 고양이 자랑합니다 (*ΦωΦ*)Ψ',
+    description:
+      '우리집에 고양이 있어용ㅎㅎ 귀엽죠  아직 7개월 애기입니당... 매일 매일 쑥쑥 크네영 너무 귀여워요ㅠㅠ',
+    thumbnail:
+      'https://species.nibr.go.kr/UPLOAD/digital/species/12000009/120000095823/BIMGMM0000386036_20221116112438319509.jpg',
+    date: new Date(2024, 2, 18),
+  },
+  {
+    username: 'zero',
+    title: 'ⓑⓘⓡⓣⓗ ⓓⓐⓨ🎂',
+    description:
+      '저 생일이에요.....🎂 혹시 다른 분도 생일이시라면 축하드립니당ㅎㅎㅎ 오늘 딱히 한 거는 없지만 그래도 기쁩니다! 여러분도 행복하세요~',
+    thumbnail:
+      'https://image.idus.com/image/files/b7a9639549fa4a2ca9d3aa3ae60496fd_512.jpg',
+    date: new Date(2024, 2, 18),
+  },
+  {
+    username: '유파랑',
+    title: '비오는 날이 좋아 ☂',
+    description:
+      '벚꽃이 떨어지는게 아쉽긴 해도 비오는 날은 역시 좋은 것 같아요! 톡톡 떨어지는 소리가 마음을 편안하게 해주는 것 같아요. 여러분은 어떤 날씨를 좋아하시나요?',
+    thumbnail:
+      'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSBMQ4MLWDwor_EWB2696OajKDKa8Zff1_XAbceJjRduw&s',
+    date: new Date(2024, 2, 18),
+  },
+  {
+    username: '이야옹',
+    title:
+      '우리집 고양이 자랑합니다 (*ΦωΦ*)Ψ 우리집 고양이 자랑합니다 (*ΦωΦ*)Ψ',
+    description:
+      '우리집에 고양이 있어용ㅎㅎ 귀엽죠  아직 7개월 애기입니당... 매일 매일 쑥쑥 크네영 너무 귀여워요ㅠㅠ',
+    thumbnail:
+      'https://species.nibr.go.kr/UPLOAD/digital/species/12000009/120000095823/BIMGMM0000386036_20221116112438319509.jpg',
+    date: new Date(2024, 2, 18),
+  },
+  {
+    username: 'zero',
+    title: 'ⓑⓘⓡⓣⓗ ⓓⓐⓨ🎂',
+    description:
+      '저 생일이에요.....🎂 혹시 다른 분도 생일이시라면 축하드립니당ㅎㅎㅎ 오늘 딱히 한 거는 없지만 그래도 기쁩니다! 여러분도 행복하세요~',
+    thumbnail:
+      'https://image.idus.com/image/files/b7a9639549fa4a2ca9d3aa3ae60496fd_512.jpg',
+    date: new Date(2024, 2, 18),
+  },
+  {
+    username: '유파랑',
+    title: '비오는 날이 좋아 ☂',
+    description:
+      '벚꽃이 떨어지는게 아쉽긴 해도 비오는 날은 역시 좋은 것 같아요! 톡톡 떨어지는 소리가 마음을 편안하게 해주는 것 같아요. 여러분은 어떤 날씨를 좋아하시나요?',
+    thumbnail:
+      'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSBMQ4MLWDwor_EWB2696OajKDKa8Zff1_XAbceJjRduw&s',
+    date: new Date(2024, 2, 18),
+  },
+] as const;
+
+const Example: Story = {
+  render: () => (
+    <div className="flex flex-col gap-6">
+      {exampleData.map((data, index) => (
+        <StackedPostCard key={index} {...data} />
+      ))}
+    </div>
+  ),
+};
+
+export { Example, Playground };
+export default meta;

--- a/components/ui-unstable/stacked-post-card.tsx
+++ b/components/ui-unstable/stacked-post-card.tsx
@@ -1,0 +1,55 @@
+import Image from 'next/image';
+
+import { AspectRatio } from '@radix-ui/react-aspect-ratio';
+import { format } from 'date-fns';
+
+type StackedPostCardProps = {
+  username: string;
+  title: string;
+  description: string;
+  thumbnail: string;
+  date: Date;
+};
+
+const StackedPostCard = ({
+  username,
+  title,
+  description,
+  thumbnail,
+  date,
+}: StackedPostCardProps) => {
+  const formattedDate = format(date, 'yyyy. MM. dd.');
+
+  return (
+    <div className="flex h-20 items-center gap-2 py-2">
+      <div className="flex w-full flex-col gap-2">
+        <h3 className="line-clamp-1 text-sm">{title}</h3>
+        <div className="flex flex-col gap-1">
+          <p className="line-clamp-2 text-xs font-light text-blccu-neutral-600">
+            {description}
+          </p>
+          <div className="flex items-center gap-2">
+            <p className="line-clamp-1 max-w-28 text-2xs font-light text-blccu-neutral-400">
+              {username}
+            </p>
+            <p className="text-2xs font-light text-blccu-neutral-400">
+              {formattedDate}
+            </p>
+          </div>
+        </div>
+      </div>
+      <div className="w-20 flex-shrink-0">
+        <AspectRatio ratio={1}>
+          <Image
+            src={thumbnail}
+            alt="thumbnail"
+            fill
+            className="rounded-md object-cover"
+          />
+        </AspectRatio>
+      </div>
+    </div>
+  );
+};
+
+export { StackedPostCard };

--- a/components/ui-unstable/stacked-user-card.stories.tsx
+++ b/components/ui-unstable/stacked-user-card.stories.tsx
@@ -1,0 +1,118 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { StackedUserCard } from '@/components/ui-unstable/stacked-user-card';
+import { Button } from '@/components/ui/button';
+
+const meta: Meta<typeof StackedUserCard> = {
+  title: 'Unstable/StackedUserCard',
+  component: StackedUserCard,
+  argTypes: {
+    avatar: {
+      control: {
+        type: 'text',
+      },
+    },
+    username: {
+      control: {
+        type: 'text',
+      },
+    },
+    description: {
+      control: {
+        type: 'text',
+      },
+    },
+  },
+  parameters: {
+    controls: {
+      exclude: ['right'],
+    },
+  },
+};
+
+type Story = StoryObj<typeof StackedUserCard>;
+
+const Playground: Story = {
+  args: {
+    avatar:
+      'https://preview.free3d.com/img/2018/04/2269230414092568255/4t4ll0dg.jpg',
+    username: '이오리',
+    description:
+      '인테리어나 집꾸미기에 관심이 많아요! 여러분의 집도 함께 꾸며드릴까요?',
+    right: <Button size="sm">팔로우</Button>,
+  },
+};
+
+const exampleData = [
+  {
+    avatar:
+      'https://preview.free3d.com/img/2018/04/2269230414092568255/4t4ll0dg.jpg',
+    username: '이오리',
+    description:
+      '인테리어나 집꾸미기에 관심이 많아요! 여러분의 집도 함께 꾸며드릴까요?',
+    right: <Button size="sm">팔로우</Button>,
+  },
+  {
+    avatar:
+      'https://upload.wikimedia.org/wikipedia/commons/thumb/b/b2/Loutre_g%C3%A9ante_gros_plan.jpg/1200px-Loutre_g%C3%A9ante_gros_plan.jpg',
+    username: '김수달',
+    description: '여러분과 함께 즐거운 시간을 보내고 싶어요.',
+    right: (
+      <Button size="sm" variant="secondary">
+        팔로잉
+      </Button>
+    ),
+  },
+  {
+    avatar:
+      'https://images.chosun.com/resizer/ebyov8zMQwFBKMq6NLp3W0MAtCs=/500x475/smart/cloudfront-ap-northeast-1.images.arcpublishing.com/chosun/NRVFQKTQC5DCXNDXPJMTONFHJA.jpg',
+    username: '양가람',
+    description: '여행을 좋아하는 양가람입니다.',
+  },
+  {
+    avatar:
+      'https://preview.free3d.com/img/2018/04/2269230414092568255/4t4ll0dg.jpg',
+    username: '이오리',
+    description:
+      '인테리어나 집꾸미기에 관심이 많아요! 여러분의 집도 함께 꾸며드릴까요?',
+    right: <Button size="sm">팔로우</Button>,
+  },
+  {
+    avatar:
+      'https://upload.wikimedia.org/wikipedia/commons/thumb/b/b2/Loutre_g%C3%A9ante_gros_plan.jpg/1200px-Loutre_g%C3%A9ante_gros_plan.jpg',
+    username: '김수달',
+    description: '여러분과 함께 즐거운 시간을 보내고 싶어요.',
+    right: (
+      <Button size="sm" variant="secondary">
+        팔로잉
+      </Button>
+    ),
+  },
+  {
+    avatar:
+      'https://images.chosun.com/resizer/ebyov8zMQwFBKMq6NLp3W0MAtCs=/500x475/smart/cloudfront-ap-northeast-1.images.arcpublishing.com/chosun/NRVFQKTQC5DCXNDXPJMTONFHJA.jpg',
+    username: '양가람',
+    description: '여행을 좋아하는 양가람입니다.',
+    right: <Button size="sm">팔로우</Button>,
+  },
+  {
+    avatar:
+      'https://preview.free3d.com/img/2018/04/2269230414092568255/4t4ll0dg.jpg',
+    username: '이오리',
+    description:
+      '인테리어나 집꾸미기에 관심이 많아요! 여러분의 집도 함께 꾸며드릴까요?',
+  },
+] as const;
+
+const Example: Story = {
+  render: () => (
+    <div className="flex flex-col gap-2">
+      {exampleData.map((data, index) => (
+        <StackedUserCard key={index} {...data} />
+      ))}
+    </div>
+  ),
+};
+
+export { Example, Playground };
+export default meta;

--- a/components/ui-unstable/stacked-user-card.tsx
+++ b/components/ui-unstable/stacked-user-card.tsx
@@ -1,0 +1,39 @@
+import { type ReactNode } from 'react';
+
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+
+type StackedUserCardProps = {
+  avatar: string;
+  username: string;
+  description?: string;
+  right?: ReactNode;
+};
+
+const StackedUserCard = ({
+  avatar,
+  username,
+  description,
+  right,
+}: StackedUserCardProps) => {
+  return (
+    <div className="flex items-center gap-4 py-2">
+      <Avatar>
+        <AvatarImage src={avatar} />
+        <AvatarFallback className="bg-blccu-neutral-400" />
+      </Avatar>
+      <div className="flex flex-1 flex-col gap-0.5">
+        <h3 className="line-clamp-1 font-medium text-blccu-neutral-600">
+          {username}
+        </h3>
+        {description !== undefined && (
+          <p className="line-clamp-1 text-xs text-blccu-neutral-400">
+            {description}
+          </p>
+        )}
+      </div>
+      {right !== undefined && right}
+    </div>
+  );
+};
+
+export { StackedUserCard };

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -12,7 +12,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
         type={type}
         className={cn(
           'flex w-full rounded-md px-4 py-3 text-sm transition',
-          'border border-blccu-input',
+          'border border-blccu-input bg-blccu-input/20',
           'file:border-0 file:bg-transparent file:text-sm file:font-medium',
           'placeholder:text-blccu-neutral-600',
           'focus-visible:border-blccu-black focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blccu-ring',

--- a/components/ui/responsive-masonry.stories.tsx
+++ b/components/ui/responsive-masonry.stories.tsx
@@ -1,0 +1,83 @@
+import Masonry, { ResponsiveMasonry } from 'react-responsive-masonry';
+
+import { type Meta, type StoryObj } from '@storybook/react';
+
+import { AutoHeightImage } from '@/components/ui-unstable/auto-height-image';
+
+const meta: Meta<typeof ResponsiveMasonry> = {
+  title: 'Components/ResponsiveMasonry',
+  component: ResponsiveMasonry,
+};
+
+type Story = StoryObj<typeof ResponsiveMasonry>;
+
+const examplePhotos = [
+  'https://images.unsplash.com/photo-1646187043863-d34d6f85ae93?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3wxMTc3M3wwfDF8c2VhcmNofDV8fCVFQyVBMCU5QyVFQyVBMyVCQyVFQiU4RiU4NHxlbnwwfHx8fDE3MTI4NTY2OTd8MA&ixlib=rb-4.0.3&q=80&w=2000',
+  'https://media.licdn.com/dms/image/D5612AQFZIgb14PcZcQ/article-cover_image-shrink_720_1280/0/1712832990937?e=1718841600&v=beta&t=rkC9GhFLLCKpSC_EGubZxcYQfFYfhSDB7cz4_x1UnN0',
+  'https://www.lgcns.com/wp-content/uploads/2021/11/276D393458F07A4F04.png',
+  'https://thumb.ac-illust.com/37/37405b48206e100357550676fd124a8f_t.jpeg',
+  'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSYyOevSjb-FLCa7OVwOcPAp7cj4w2gNm2F2K9koBr4uQ&s',
+  'https://img.hankyung.com/photo/202009/AA.23690748.1.jpg',
+  'https://blog.altair.co.kr/wp-content/uploads/2021/06/large-895567_1920-1024x577.jpg',
+  'https://thumb.ac-illust.com/37/37405b48206e100357550676fd124a8f_t.jpeg',
+  'https://media.licdn.com/dms/image/D5612AQFZIgb14PcZcQ/article-cover_image-shrink_720_1280/0/1712832990937?e=1718841600&v=beta&t=rkC9GhFLLCKpSC_EGubZxcYQfFYfhSDB7cz4_x1UnN0',
+  'https://www.lgcns.com/wp-content/uploads/2021/11/276D393458F07A4F04.png',
+  'https://png.pngtree.com/thumb_back/fh260/background/20201012/pngtree-rainy-sky-background-image_410908.jpg',
+  'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSRvFR_pTwpwLHPvcVSfpN1kdh76k78qi01ZqsU3M7CNw&s',
+  'https://img.hankyung.com/photo/202009/AA.23690748.1.jpg',
+  'https://blog.altair.co.kr/wp-content/uploads/2021/06/large-895567_1920-1024x577.jpg',
+  'https://images.unsplash.com/photo-1646187043863-d34d6f85ae93?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3wxMTc3M3wwfDF8c2VhcmNofDV8fCVFQyVBMCU5QyVFQyVBMyVCQyVFQiU4RiU4NHxlbnwwfHx8fDE3MTI4NTY2OTd8MA&ixlib=rb-4.0.3&q=80&w=2000',
+  'https://media.licdn.com/dms/image/D5612AQFZIgb14PcZcQ/article-cover_image-shrink_720_1280/0/1712832990937?e=1718841600&v=beta&t=rkC9GhFLLCKpSC_EGubZxcYQfFYfhSDB7cz4_x1UnN0',
+  'https://www.lgcns.com/wp-content/uploads/2021/11/276D393458F07A4F04.png',
+  'https://png.pngtree.com/thumb_back/fh260/background/20201012/pngtree-rainy-sky-background-image_410908.jpg',
+  'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSRvFR_pTwpwLHPvcVSfpN1kdh76k78qi01ZqsU3M7CNw&s',
+  'https://thumb.ac-illust.com/37/37405b48206e100357550676fd124a8f_t.jpeg',
+  'https://blog.altair.co.kr/wp-content/uploads/2021/06/large-895567_1920-1024x577.jpg',
+  'https://images.unsplash.com/photo-1646187043863-d34d6f85ae93?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3wxMTc3M3wwfDF8c2VhcmNofDV8fCVFQyVBMCU5QyVFQyVBMyVCQyVFQiU4RiU4NHxlbnwwfHx8fDE3MTI4NTY2OTd8MA&ixlib=rb-4.0.3&q=80&w=2000',
+  'https://media.licdn.com/dms/image/D5612AQFZIgb14PcZcQ/article-cover_image-shrink_720_1280/0/1712832990937?e=1718841600&v=beta&t=rkC9GhFLLCKpSC_EGubZxcYQfFYfhSDB7cz4_x1UnN0',
+  'https://www.lgcns.com/wp-content/uploads/2021/11/276D393458F07A4F04.png',
+  'https://png.pngtree.com/thumb_back/fh260/background/20201012/pngtree-rainy-sky-background-image_410908.jpg',
+  'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSRvFR_pTwpwLHPvcVSfpN1kdh76k78qi01ZqsU3M7CNw&s',
+  'https://img.hankyung.com/photo/202009/AA.23690748.1.jpg',
+  'https://blog.altair.co.kr/wp-content/uploads/2021/06/large-895567_1920-1024x577.jpg',
+  'https://images.unsplash.com/photo-1646187043863-d34d6f85ae93?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3wxMTc3M3wwfDF8c2VhcmNofDV8fCVFQyVBMCU5QyVFQyVBMyVCQyVFQiU4RiU4NHxlbnwwfHx8fDE3MTI4NTY2OTd8MA&ixlib=rb-4.0.3&q=80&w=2000',
+  'https://media.licdn.com/dms/image/D5612AQFZIgb14PcZcQ/article-cover_image-shrink_720_1280/0/1712832990937?e=1718841600&v=beta&t=rkC9GhFLLCKpSC_EGubZxcYQfFYfhSDB7cz4_x1UnN0',
+  'https://www.lgcns.com/wp-content/uploads/2021/11/276D393458F07A4F04.png',
+  'https://png.pngtree.com/thumb_back/fh260/background/20201012/pngtree-rainy-sky-background-image_410908.jpg',
+  'https://thumb.ac-illust.com/37/37405b48206e100357550676fd124a8f_t.jpeg',
+  'https://img.hankyung.com/photo/202009/AA.23690748.1.jpg',
+  'https://thumb.ac-illust.com/37/37405b48206e100357550676fd124a8f_t.jpeg',
+  'https://images.unsplash.com/photo-1646187043863-d34d6f85ae93?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3wxMTc3M3wwfDF8c2VhcmNofDV8fCVFQyVBMCU5QyVFQyVBMyVCQyVFQiU4RiU4NHxlbnwwfHx8fDE3MTI4NTY2OTd8MA&ixlib=rb-4.0.3&q=80&w=2000',
+  'https://media.licdn.com/dms/image/D5612AQFZIgb14PcZcQ/article-cover_image-shrink_720_1280/0/1712832990937?e=1718841600&v=beta&t=rkC9GhFLLCKpSC_EGubZxcYQfFYfhSDB7cz4_x1UnN0',
+  'https://www.lgcns.com/wp-content/uploads/2021/11/276D393458F07A4F04.png',
+  'https://png.pngtree.com/thumb_back/fh260/background/20201012/pngtree-rainy-sky-background-image_410908.jpg',
+  'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSRvFR_pTwpwLHPvcVSfpN1kdh76k78qi01ZqsU3M7CNw&s',
+  'https://img.hankyung.com/photo/202009/AA.23690748.1.jpg',
+  'https://blog.altair.co.kr/wp-content/uploads/2021/06/large-895567_1920-1024x577.jpg',
+];
+
+const Example: Story = {
+  render: () => (
+    <ResponsiveMasonry
+      columnsCountBreakPoints={{
+        0: 1,
+        240: 2,
+        360: 3,
+      }}
+    >
+      <Masonry gutter="10px">
+        {examplePhotos.map((photo, index) => (
+          <AutoHeightImage
+            key={index}
+            src={photo}
+            alt="photo"
+            className="rounded-md"
+          />
+        ))}
+      </Masonry>
+    </ResponsiveMasonry>
+  ),
+};
+
+export { Example };
+export default meta;

--- a/components/ui/scroll-area.tsx
+++ b/components/ui/scroll-area.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import * as React from 'react';
+
+import * as ScrollAreaPrimitive from '@radix-ui/react-scroll-area';
+
+import { cn } from '@/lib/utils';
+
+const ScrollArea = React.forwardRef<
+  React.ElementRef<typeof ScrollAreaPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root>
+>(({ className, children, ...props }, ref) => (
+  <ScrollAreaPrimitive.Root
+    ref={ref}
+    className={cn('relative overflow-hidden', className)}
+    {...props}
+  >
+    <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-[inherit]">
+      {children}
+    </ScrollAreaPrimitive.Viewport>
+    <ScrollBar />
+    <ScrollAreaPrimitive.Corner />
+  </ScrollAreaPrimitive.Root>
+));
+ScrollArea.displayName = ScrollAreaPrimitive.Root.displayName;
+
+const ScrollBar = React.forwardRef<
+  React.ElementRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>,
+  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>
+>(({ className, orientation = 'vertical', ...props }, ref) => (
+  <ScrollAreaPrimitive.ScrollAreaScrollbar
+    ref={ref}
+    orientation={orientation}
+    className={cn(
+      'flex touch-none select-none transition-colors',
+      orientation === 'vertical' &&
+        'h-full w-2.5 border-l border-l-transparent p-[1px]',
+      orientation === 'horizontal' &&
+        'h-2.5 flex-col border-t border-t-transparent p-[1px]',
+      className,
+    )}
+    {...props}
+  >
+    <ScrollAreaPrimitive.ScrollAreaThumb className="relative flex-1 rounded-full bg-border" />
+  </ScrollAreaPrimitive.ScrollAreaScrollbar>
+));
+ScrollBar.displayName = ScrollAreaPrimitive.ScrollAreaScrollbar.displayName;
+
+export { ScrollArea, ScrollBar };

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -21,10 +21,10 @@ const SelectTrigger = React.forwardRef<
     ref={ref}
     className={cn(
       'flex w-full items-center justify-between rounded-md bg-background px-4 py-3 text-sm transition',
-      'border border-blccu-input',
+      'border border-blccu-input bg-blccu-input/20',
       'placeholder:text-blccu-neutral-600',
       'focus:border-blccu-black focus:outline-none focus:ring-2 focus:ring-blccu-ring',
-      'disabled:bg-blccu-neutral-200/50 disabled:cursor-not-allowed disabled:opacity-50',
+      'disabled:cursor-not-allowed disabled:bg-blccu-neutral-200/50 disabled:opacity-50',
       '[&>span]:line-clamp-1',
       className,
     )}

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -11,7 +11,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
       <textarea
         className={cn(
           'flex min-h-[80px] w-full resize-none rounded-md px-3 py-2 text-sm transition',
-          'border border-blccu-input',
+          'border border-blccu-input bg-blccu-input/20',
           'placeholder:text-blccu-neutral-600',
           'focus-visible:border-blccu-black focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blccu-ring',
           'disabled:cursor-not-allowed disabled:opacity-50',

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "react": "^18",
     "react-dom": "^18",
     "react-hook-form": "^7.51.2",
+    "react-responsive-masonry": "^2.2.0",
     "tailwind-merge": "^2.2.2",
     "tailwindcss-animate": "^1.0.7",
     "zod": "^3.22.4"
@@ -60,6 +61,7 @@
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",
+    "@types/react-responsive-masonry": "^2.1.3",
     "@typescript-eslint/eslint-plugin": "^7.5.0",
     "@typescript-eslint/parser": "^7.5.0",
     "autoprefixer": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@radix-ui/react-dialog": "^1.0.5",
     "@radix-ui/react-label": "^2.0.2",
     "@radix-ui/react-radio-group": "^1.1.3",
+    "@radix-ui/react-scroll-area": "^1.0.5",
     "@radix-ui/react-select": "^2.0.0",
     "@radix-ui/react-slot": "^1.0.2",
     "@radix-ui/react-toast": "^1.1.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,9 @@ dependencies:
   react-hook-form:
     specifier: ^7.51.2
     version: 7.51.2(react@18.2.0)
+  react-responsive-masonry:
+    specifier: ^2.2.0
+    version: 2.2.0
   tailwind-merge:
     specifier: ^2.2.2
     version: 2.2.2
@@ -133,6 +136,9 @@ devDependencies:
   '@types/react-dom':
     specifier: ^18
     version: 18.2.24
+  '@types/react-responsive-masonry':
+    specifier: ^2.1.3
+    version: 2.1.3
   '@typescript-eslint/eslint-plugin':
     specifier: ^7.5.0
     version: 7.5.0(@typescript-eslint/parser@7.5.0)(eslint@8.57.0)(typescript@5.4.4)
@@ -4075,6 +4081,12 @@ packages:
     resolution: {integrity: sha512-cN6upcKd8zkGy4HU9F1+/s98Hrp6D4MOcippK4PoE8OZRngohHZpbJn1GsaDLz87MqvHNoT13nHvNqM9ocRHZg==}
     dependencies:
       '@types/react': 18.2.74
+
+  /@types/react-responsive-masonry@2.1.3:
+    resolution: {integrity: sha512-aOFUtv3QwNMmy0BgpQpvivQ/+vivMTB6ARrzf9eTSXsLzXpVnfEtjpHpSknYDnr8KaQmlgeauAj8E7wo/qMOTg==}
+    dependencies:
+      '@types/react': 18.2.74
+    dev: true
 
   /@types/react@18.2.74:
     resolution: {integrity: sha512-9AEqNZZyBx8OdZpxzQlaFEVCSFUM2YXJH46yPOiOpm078k6ZLOCcuAzGum/zK8YBwY+dbahVNbHrbgrAwIRlqw==}
@@ -9875,6 +9887,10 @@ packages:
       tslib: 2.6.2
       use-callback-ref: 1.3.2(@types/react@18.2.74)(react@18.2.0)
       use-sidecar: 1.1.2(@types/react@18.2.74)(react@18.2.0)
+    dev: false
+
+  /react-responsive-masonry@2.2.0:
+    resolution: {integrity: sha512-IYbnfe2tWCZ3pvyTLyBWPj7uv5ZmNOULYMcAZi5a47ZLhSotOck1vkkISq6gP2qiyWdMvPfeMhjvYzUYGw9BOQ==}
     dev: false
 
   /react-style-singleton@2.2.1(@types/react@18.2.74)(react@18.2.0):

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ dependencies:
   '@radix-ui/react-radio-group':
     specifier: ^1.1.3
     version: 1.1.3(@types/react-dom@18.2.24)(@types/react@18.2.74)(react-dom@18.2.0)(react@18.2.0)
+  '@radix-ui/react-scroll-area':
+    specifier: ^1.0.5
+    version: 1.0.5(@types/react-dom@18.2.24)(@types/react@18.2.74)(react-dom@18.2.0)(react@18.2.0)
   '@radix-ui/react-select':
     specifier: ^2.0.0
     version: 2.0.0(@types/react-dom@18.2.24)(@types/react@18.2.74)(react-dom@18.2.0)(react@18.2.0)
@@ -2616,6 +2619,35 @@ packages:
       '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.24)(@types/react@18.2.74)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.74)(react@18.2.0)
       '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@18.2.74)(react@18.2.0)
+      '@types/react': 18.2.74
+      '@types/react-dom': 18.2.24
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
+  /@radix-ui/react-scroll-area@1.0.5(@types/react-dom@18.2.24)(@types/react@18.2.74)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-b6PAgH4GQf9QEn8zbT2XUHpW5z8BzqEc7Kl11TwDrvuTrxlkcjTD5qa/bxgKr+nmuXKu4L/W5UZ4mlP/VG/5Gw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.24.4
+      '@radix-ui/number': 1.0.1
+      '@radix-ui/primitive': 1.0.1
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.74)(react@18.2.0)
+      '@radix-ui/react-context': 1.0.1(@types/react@18.2.74)(react@18.2.0)
+      '@radix-ui/react-direction': 1.0.1(@types/react@18.2.74)(react@18.2.0)
+      '@radix-ui/react-presence': 1.0.1(@types/react-dom@18.2.24)(@types/react@18.2.74)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.24)(@types/react@18.2.74)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.74)(react@18.2.0)
+      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.2.74)(react@18.2.0)
       '@types/react': 18.2.74
       '@types/react-dom': 18.2.24
       react: 18.2.0

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -19,19 +19,19 @@ const config = {
     extend: {
       colors: {
         blccu: {
-          white: 'var(--blccu-white)',
+          white: 'rgb(var(--blccu-white) / <alpha-value>)',
           neutral: {
-            200: 'var(--blccu-neutral-200)',
-            400: 'var(--blccu-neutral-400)',
-            600: 'var(--blccu-neutral-600)',
-            800: 'var(--blccu-neutral-800)',
+            200: 'rgb(var(--blccu-neutral-200) / <alpha-value>)',
+            400: 'rgb(var(--blccu-neutral-400) / <alpha-value>)',
+            600: 'rgb(var(--blccu-neutral-600) / <alpha-value>)',
+            800: 'rgb(var(--blccu-neutral-800) / <alpha-value>)',
           },
-          black: 'var(--blccu-black)',
-          red: 'var(--blccu-red)',
-          input: 'var(--blccu-input)',
-          ring: 'var(--blccu-ring)',
-          background: 'var(--blccu-background)',
-          foreground: 'var(--blccu-foreground)',
+          black: 'rgb(var(--blccu-black) / <alpha-value>)',
+          red: 'rgb(var(--blccu-red) / <alpha-value>)',
+          input: 'rgb(var(--blccu-input) / <alpha-value>)',
+          ring: 'rgb(var(--blccu-ring) / <alpha-value>)',
+          background: 'rgb(var(--blccu-background) / <alpha-value>)',
+          foreground: 'rgb(var(--blccu-foreground) / <alpha-value>)',
         },
         border: 'hsl(var(--border))',
         input: 'hsl(var(--input))',
@@ -85,6 +85,9 @@ const config = {
       animation: {
         'accordion-down': 'accordion-down 0.2s ease-out',
         'accordion-up': 'accordion-up 0.2s ease-out',
+      },
+      fontSize: {
+        '2xs': '0.625rem' /* 10px */,
       },
     },
   },


### PR DESCRIPTION
## Summary

여러 페이지에서 공통으로 필요한 컴포넌트 제작 중입니다. 

[피그마](https://www.figma.com/file/5k7EFuQKRQBVUvxbquFBm4/Team-Sprint?type=design&node-id=84-394&mode=design&t=bGOflsemw8bzWghF-0) 기준으로 제작하였습니다. 

피그마 시안 상 **컴포넌트화, Variant, 4의 배수 px 등의 규칙이 지켜지지 않은 상태**입니다. 
따라서 색상은 최대한 맞추되, 여백이나 폰트는 느낌만 가져가고 규칙에 맞추는 방식으로 작업해야 합니다. 

#4 의 말미에 언급하였던 작업 진행 계획 중 2번째 작업에 해당합니다. 
> 1. shadcn/ui 컴포넌트 커스텀하기 - 피그마 시안 보고 필요한 variant만 남기는 방식으로 커스텀
> 2. **shadcn/ui에는 없지만 필요한 기본 컴포넌트 제작하기**
> 3. 피그마 시안에 따라 뷰 스캐폴딩
> 4. 백엔드와 로직 연결

아직 다음의 컴포넌트를 제작하지 않았습니다. 
- AppBar (상단 뒤로가기 앱바)
- BottomNavigationBar (홈화면 하단 바)
- 댓글 컴포넌트
- 기타 스토리북에 없는 컴포넌트는 전부 미제작 상태입니다.

하지만 위 컴포넌트는 3단계를 진행하면서 제작하기로 결정하였습니다. 
1. 너무 지엽적이라 미리 만들었을 때 이점이 없는 경우 (ex. 댓글 컴포넌트)
2. 개발 시 직접 사용하다보면 고칠게 뻔한 경우 (ex. AppBar)

## Describe your changes

`components/ui` 폴더 내의 변경사항은 다음과 같습니다. 
- BottomRadioGroup 제작
- ScrollArea 추가 (from shadcn/ui)
- HorizontalScrollablePostCard 제작
- StackedPostCard 제작
- StackedUserCard 제작
- AutoHeightImage 제작
  - 기존 next/image의 Image 컴포넌트는 height를 미리 정하고 가져와야 하는 문제가 있음
- ResponsiveMasonry 제작
  - 라이브러리 없이 제작하려 하였으나, 로직이 매끄럽지 못해 *react-responsive-masonry* 라이브러리를 이용함
- BottomActionSheet 제작 (from Sheet)

컴포넌트명이 생소하다면, 스토리북을 통해 사용 예시를 확인하실 수 있습니다. 

### ui-unstable에 대하여

직접 만든 컴포넌트의 경우, 개발 단계에서 바뀔 여지가 많다고 생각이 되어 **ui-unstable** 폴더에 모아두었습니다. 
- 웹 접근성 상 부적절합니다. 
- Props가 변경될 수 있습니다. 

예시로 설명드리자면, 
- ButtonRadioGroup은 웹 접근성 상 RadioGroup으로 동작하여야 하나 내부 구현 상 그렇지 않습니다. 
- BottomActionSheet은 웹 접근성 상 Menu로 동작 (탭, 화살표로 MenuItem 선택 가능)하여야 하나 내부 구현 상 그렇지 않습니다. 

<img width="319" alt="image" src="https://github.com/DevKor-github/team-sprint-blccu-frontend/assets/61629480/f39fdc9b-448e-4b43-927e-d60f4f2e7ce9">
<img width="320" alt="image" src="https://github.com/DevKor-github/team-sprint-blccu-frontend/assets/61629480/07233a41-4ad6-4e4b-8598-1382fee4fe82">

추후 모든 용례에서 정상 동작하는 경우 **ui** 폴더로 옮길 예정입니다. 

### ui-experimental에 대하여

~~실패작 모아놓는 공간~~

ResponsiveMasonry를 직접 개발하려고 했었..습니다만, 
만들 때는 꽤 만족했으나 막상 완성하니 동작이 매우 석연치 않아서 라이브러리로 대체하였습니다. 

추후 충분히 완성할 수 있을 것 같아 **ui-experimental** 폴더에 담아두었습니다. 
스토리북에서도 작동을 확인하실 수 있습니다. 

그 외 변경사항은 다음과 같습니다. 
- d61132ced84a4f00f6041d3d9c9c86bc8f495cf6 `bg-blccu-black/20` 등의 방식으로 사용 시 opacity가 작동하지 않는 문제 해결 
- da4b21326ab6e2c7b5972b53a78097ce74ef4c69 폰트 굵기에 light 추가
- bad9716182d01747ef683036fd26701e52c8ba89 스토리북 기본 width를 320px로 축소
- d8718fd04860e74968a43990911b209044d25e43 스토리북 정렬 조건 추가 (components → unstable → experimental)

## Issue number and link
- #4 
- #7