### PR TITLE
chore: remove slug, remove UUID

### DIFF
--- a/app/(public)/users/[userHandle]/posts/[postId]/comments/page.tsx
+++ b/app/(public)/users/[userHandle]/posts/[postId]/comments/page.tsx
@@ -15,7 +15,7 @@ import { generateCommentsWithReplies } from '@/lib/utils';
 type CommentsPageProps = {
   params: {
     userHandle: string;
-    slug: string;
+    postId: number;
   };
 };
 
@@ -26,7 +26,7 @@ const commentsWithReplies = generateCommentsWithReplies(
 );
 
 const CommentsPage = ({
-  params: { userHandle: _, slug: __ },
+  params: { userHandle: _, postId: __ },
 }: CommentsPageProps) => {
   return (
     <>

--- a/app/(public)/users/[userHandle]/posts/[postId]/page.tsx
+++ b/app/(public)/users/[userHandle]/posts/[postId]/page.tsx
@@ -23,11 +23,11 @@ const { author, thumbnail } = post;
 type PostPageProps = {
   params: {
     userHandle: string;
-    slug: string;
+    postId: number;
   };
 };
 
-const PostPage = ({ params: { userHandle: _, slug: __ } }: PostPageProps) => {
+const PostPage = ({ params: { userHandle: _, postId: __ } }: PostPageProps) => {
   return (
     <>
       <AppBar className="border-b-0 bg-blccu-white/90 backdrop-blur-lg">

--- a/app/(signed-in-only)/report/comments/[commentId]/page.tsx
+++ b/app/(signed-in-only)/report/comments/[commentId]/page.tsx
@@ -2,7 +2,6 @@
 
 import { useRouter } from 'next/navigation';
 
-import { type UUID } from 'crypto';
 import { toast } from 'sonner';
 
 import {
@@ -24,7 +23,7 @@ const { author, id: postId } = post;
 
 type ReportCommentIdPageProps = {
   params: {
-    postId: UUID;
+    postId: number;
   };
 };
 

--- a/app/(signed-in-only)/report/comments/[commentId]/page.tsx
+++ b/app/(signed-in-only)/report/comments/[commentId]/page.tsx
@@ -20,7 +20,7 @@ import { generatePost } from '@/lib/utils';
 
 const post = generatePost();
 
-const { author, slug } = post;
+const { author, id: postId } = post;
 
 type ReportCommentIdPageProps = {
   params: {
@@ -36,7 +36,7 @@ const ReportCommentIdPage = ({
   const handleClick = () => {
     toast.success(TOAST_MESSAGES.REPORT_COMMENT_SUCCESS);
 
-    router.push(ROUTES.COMMENTS_OF(author.handle, slug));
+    router.push(ROUTES.COMMENTS_OF(author.handle, postId));
   };
 
   return (

--- a/app/(signed-in-only)/report/posts/[postId]/page.tsx
+++ b/app/(signed-in-only)/report/posts/[postId]/page.tsx
@@ -2,7 +2,6 @@
 
 import { useRouter } from 'next/navigation';
 
-import { type UUID } from 'crypto';
 import { toast } from 'sonner';
 
 import {
@@ -24,7 +23,7 @@ const { author, id: postId } = post;
 
 type ReportPostIdPageProps = {
   params: {
-    postId: UUID;
+    postId: number;
   };
 };
 

--- a/app/(signed-in-only)/report/posts/[postId]/page.tsx
+++ b/app/(signed-in-only)/report/posts/[postId]/page.tsx
@@ -20,7 +20,7 @@ import { generatePost } from '@/lib/utils';
 
 const post = generatePost();
 
-const { author, slug } = post;
+const { author, id: postId } = post;
 
 type ReportPostIdPageProps = {
   params: {
@@ -34,7 +34,7 @@ const ReportPostIdPage = ({ params: { postId: _ } }: ReportPostIdPageProps) => {
   const handleClick = () => {
     toast.success(TOAST_MESSAGES.REPORT_POST_SUCCESS);
 
-    router.push(ROUTES.POST_OF(author.handle, slug));
+    router.push(ROUTES.POST_OF(author.handle, postId));
   };
 
   return (

--- a/constants/dummy.ts
+++ b/constants/dummy.ts
@@ -74,79 +74,79 @@ const BLCCU_DUMMY_DATASET = {
   POST: {
     BASICS: [
       {
+        id: 1,
         title: '눈사람 만드는 법',
-        slug: 'how-to-build-a-snowman',
         description: '오늘같은 날씨엔 눈사람 만드는 것이 최고죠! 🌨',
       },
       {
+        id: 2,
         title: '비오는 날이 좋아 ☂',
-        slug: 'rainy-day-lover',
         description:
           '벚꽃이 떨어지는게 아쉽긴 해도 비오는 날은 역시 좋은 것 같아요! 톡톡 떨어지는 소리가 마음을 편안하게 해주는 것 같아요. 여러분은 어떤 날씨를 좋아하시나요?',
       },
       {
+        id: 3,
         title: '우리집 고양이 자랑합니다 (*ΦωΦ*)Ψ',
-        slug: 'our-cat-is-cute',
         description:
           '우리집에 고양이 있어용ㅎㅎ 귀엽죠  아직 7개월 애기입니당... 매일 매일 쑥쑥 크네영 너무 귀여워요ㅠㅠ',
       },
       {
+        id: 4,
         title: 'ⓑⓘⓡⓣⓗ ⓓⓐⓨ🎂',
-        slug: 'happy-birthday-to-me',
         description:
           '저 생일이에요.....🎂 혹시 다른 분도 생일이시라면 축하드립니당ㅎㅎㅎ 오늘 딱히 한 거는 없지만 그래도 기쁩니다! 여러분도 행복하세요~',
       },
       {
+        id: 5,
         title: '나만의 티타임',
-        slug: 'tea-time',
         description:
           '차 한 잔의 여유로움이 필요할 때가 있죠. 오늘은 어떤 차를 마셔볼까요?',
       },
       {
+        id: 6,
         title: '캔들과 함께하는 힐링타임',
-        slug: 'candle-and-relax',
         description:
           '캔들 하나로도 힐링을 느낄 수 있어요. 오늘은 어떤 향기로 힐링을 받아볼까요?',
       },
       {
+        id: 7,
         title: '아늑한 방 꾸미기',
-        slug: 'is-cozy-room-possible',
         description:
           '아늑한 방 꾸미기를 해보고 싶어요. 여러분은 어떤 방 꾸미기를 좋아하시나요? 함께 공유해주세요! 🏡',
       },
       {
+        id: 8,
         title: '내가 좋아하는 향기',
-        slug: 'my-favorite-fragrance',
         description:
           '향기는 기분을 좋게 해주는 마법 같은 것이에요. 여러분은 어떤 향기를 좋아하시나요? 저는 나무 향기를 좋아해요!',
       },
       {
+        id: 9,
         title: '주방에서의 우정',
-        slug: 'friendship-in-the-kitchen',
         description:
           '친구들과 함께 요리하는 것이 얼마나 즐거운 일인지 알고 계신가요? 오늘은 친구들과 함께 요리하는 시간을 가져보세요!',
       },
       {
+        id: 10,
         title: '선생님의 꽃',
-        slug: 'life-or-death-of-a-cactus',
         description:
           '선생님께서 선물해주신 선물이 살아있는지 죽어있는지 궁금하시다면? 바로 이 글을 확인해보세요!',
       },
       {
+        id: 11,
         title: '올해의 선생님',
-        slug: 'teacher-of-the-year',
         description:
           '올해의 선생님을 뽑아보자! 여러분이 생각하시는 올해의 선생님은 누구인가요?',
       },
       {
+        id: 12,
         title: '나무 심는 법',
-        slug: 'practical-tips-for-planting-trees',
         description:
           '나무를 심는 방법을 알고 싶나요? 먼저, 나무를 심으려면 당연히 나무를 심을 곳을 정해야 해요. 그 다음으로는 씨앗을 찾아야합니다. 여러분은 어떤 나무를 심고 싶으신가요?',
       },
       {
+        id: 13,
         title: '케이크는 해답이다',
-        slug: 'cake-is-the-answer',
         description:
           '케이크를 먹으면 기분이 좋아지는 것 같아요. 제가 좋아하는 케이크는 초코케이크인데, 오늘은 딸기케이크가 너무 먹고 싶어요.',
       },

--- a/constants/routes.ts
+++ b/constants/routes.ts
@@ -22,9 +22,9 @@ const ROUTES = {
   SELECT_CATEGORY_OF: (userHandle: string) => `/@${userHandle}/select-category`,
   FOLLOWERS_OF: (userHandle: string) => `/@${userHandle}/followers`,
   FOLLOWING_OF: (userHandle: string) => `/@${userHandle}/following`,
-  POST_OF: (userHandle: string, slug: string) => `/@${userHandle}/${slug}`,
-  COMMENTS_OF: (userHandle: string, slug: string) =>
-    `/@${userHandle}/${slug}/comments`,
+  POST_OF: (userHandle: string, postId: number) => `/@${userHandle}/${postId}`,
+  COMMENTS_OF: (userHandle: string, postId: number) =>
+    `/@${userHandle}/${postId}/comments`,
 
   /* -------------------------------------------------------------------------------------------------
    * signed-in-only layout

--- a/constants/routes.ts
+++ b/constants/routes.ts
@@ -1,5 +1,3 @@
-import { type UUID } from 'crypto';
-
 const ROUTES = {
   /* -------------------------------------------------------------------------------------------------
    * not-signed-in-only layout
@@ -31,16 +29,16 @@ const ROUTES = {
    * -----------------------------------------------------------------------------------------------*/
   UPDATE_CATEGORY: '/update-category',
   CREATE_CATEGORY: '/create-category',
-  CATEGORY_ID_EDIT_OF: (categoryId: UUID) =>
+  CATEGORY_ID_EDIT_OF: (categoryId: number) =>
     `/update-category/${categoryId}/edit`,
   NOTIFICATIONS: '/notifications',
-  REPORT_COMMENT_ID_OF: (commentId: UUID) => `/report/comments/${commentId}`,
-  REPORT_POST_ID_OF: (postId: UUID) => `/report/posts/${postId}`,
+  REPORT_COMMENT_ID_OF: (commentId: number) => `/report/comments/${commentId}`,
+  REPORT_POST_ID_OF: (postId: number) => `/report/posts/${postId}`,
 
   /* settings page */
   SETTINGS: '/settings',
   ANNOUNCEMENTS: '/settings/announcements',
-  ANNOUNCEMENT_ID_OF: (announcementId: UUID) =>
+  ANNOUNCEMENT_ID_OF: (announcementId: number) =>
     `/settings/announcements/${announcementId}`,
   LEGAL: '/settings/legal',
   TERMS_OF_USE: '/settings/legal/terms-of-use',

--- a/features/comments-page/report-comment-bottom-action-sheet.tsx
+++ b/features/comments-page/report-comment-bottom-action-sheet.tsx
@@ -11,10 +11,10 @@ import {
   BottomActionSheetTrigger,
 } from '@/components/ui-unstable/bottom-action-sheet';
 import { ROUTES } from '@/constants/routes';
-import { generateUuid } from '@/lib/utils';
+import { generateId } from '@/lib/utils';
 import { type PropsWithTrigger } from '@/types/props';
 
-const uuid = generateUuid();
+const id = generateId();
 
 const ReportCommentBottomActionSheet = ({ trigger }: PropsWithTrigger) => {
   return (
@@ -22,7 +22,7 @@ const ReportCommentBottomActionSheet = ({ trigger }: PropsWithTrigger) => {
       <BottomActionSheetTrigger asChild>{trigger}</BottomActionSheetTrigger>
       <BottomActionSheetContent>
         <BottomActionSheetGroup>
-          <Link href={ROUTES.REPORT_COMMENT_ID_OF(uuid)}>
+          <Link href={ROUTES.REPORT_COMMENT_ID_OF(id)}>
             <BottomActionSheetItem className="text-blccu-red">
               신고하기
             </BottomActionSheetItem>

--- a/features/post-page/post-page-all-post-section.tsx
+++ b/features/post-page/post-page-all-post-section.tsx
@@ -29,10 +29,10 @@ const PostPageAllPostSection = ({ user }: PostPageAllPostSectionProps) => {
         <div className="flex flex-col">
           {posts.map(
             (
-              { author, title, slug, description, thumbnail, createdAt },
+              { author, title, id: postId, description, thumbnail, createdAt },
               index,
             ) => (
-              <Link href={ROUTES.POST_OF(author.handle, slug)} key={index}>
+              <Link href={ROUTES.POST_OF(author.handle, postId)} key={index}>
                 <div className="px-4 py-3">
                   <StackedPostCard
                     username={author.username}

--- a/features/post-page/post-page-bottom-bar.tsx
+++ b/features/post-page/post-page-bottom-bar.tsx
@@ -14,7 +14,7 @@ import { cn, generatePost, randomInt } from '@/lib/utils';
 
 const post = generatePost();
 
-const { slug, author } = post;
+const { id: postId, author } = post;
 
 const initialLikeCount = randomInt(0, 1000);
 const commentCount = randomInt(0, 30);
@@ -49,7 +49,7 @@ const PostPageBottomBar = () => {
           />
           <p className="text-sm">{likeCount.toLocaleString()}</p>
         </Button>
-        <Link href={ROUTES.COMMENTS_OF(author.handle, slug)}>
+        <Link href={ROUTES.COMMENTS_OF(author.handle, postId)}>
           <div className="flex items-center gap-1 px-2 py-1">
             <MessageCircleMore className="h-4 w-4" />
             <p className="text-sm">{commentCount.toLocaleString()}</p>

--- a/features/post-page/report-post-bottom-action-sheet.tsx
+++ b/features/post-page/report-post-bottom-action-sheet.tsx
@@ -11,10 +11,10 @@ import {
   BottomActionSheetTrigger,
 } from '@/components/ui-unstable/bottom-action-sheet';
 import { ROUTES } from '@/constants/routes';
-import { generateUuid } from '@/lib/utils';
+import { generateId } from '@/lib/utils';
 import { type PropsWithTrigger } from '@/types/props';
 
-const uuid = generateUuid();
+const id = generateId();
 
 const ReportPostBottomActionSheet = ({ trigger }: PropsWithTrigger) => {
   return (
@@ -22,7 +22,7 @@ const ReportPostBottomActionSheet = ({ trigger }: PropsWithTrigger) => {
       <BottomActionSheetTrigger asChild>{trigger}</BottomActionSheetTrigger>
       <BottomActionSheetContent>
         <BottomActionSheetGroup>
-          <Link href={ROUTES.REPORT_POST_ID_OF(uuid)}>
+          <Link href={ROUTES.REPORT_POST_ID_OF(id)}>
             <BottomActionSheetItem className="text-blccu-red">
               신고하기
             </BottomActionSheetItem>

--- a/features/root-page/all-post-section.tsx
+++ b/features/root-page/all-post-section.tsx
@@ -28,8 +28,8 @@ const AllPostSection = () => {
             }}
           >
             <Masonry gutter="10px">
-              {posts.map(({ author, slug, thumbnail }, index) => (
-                <Link href={ROUTES.POST_OF(author.handle, slug)} key={index}>
+              {posts.map(({ author, id: postId, thumbnail }, index) => (
+                <Link href={ROUTES.POST_OF(author.handle, postId)} key={index}>
                   <img src={thumbnail} alt="photo" className="rounded-md" />
                 </Link>
               ))}

--- a/features/root-page/follower-post-section.tsx
+++ b/features/root-page/follower-post-section.tsx
@@ -19,10 +19,10 @@ const FollowerPostSection = () => {
         <div className="flex flex-col">
           {posts.map(
             (
-              { author, title, slug, description, thumbnail, createdAt },
+              { author, title, id: postId, description, thumbnail, createdAt },
               index,
             ) => (
-              <Link href={ROUTES.POST_OF(author.handle, slug)} key={index}>
+              <Link href={ROUTES.POST_OF(author.handle, postId)} key={index}>
                 <div className="px-4 py-3">
                   <StackedPostCard
                     username={author.username}

--- a/features/root-page/trending-post-section.tsx
+++ b/features/root-page/trending-post-section.tsx
@@ -21,10 +21,17 @@ const TrendingPostSection = () => {
           <div className="mr-4 flex gap-3 pb-4">
             {posts.map(
               (
-                { author, title, slug, description, thumbnail, createdAt },
+                {
+                  author,
+                  title,
+                  id: postId,
+                  description,
+                  thumbnail,
+                  createdAt,
+                },
                 index,
               ) => (
-                <Link href={ROUTES.POST_OF(author.handle, slug)} key={index}>
+                <Link href={ROUTES.POST_OF(author.handle, postId)} key={index}>
                   <HorizontalScrollablePostCard
                     username={author.username}
                     userHandle={author.handle}

--- a/features/update-category-page/update-category-page-bottom-action-sheet.tsx
+++ b/features/update-category-page/update-category-page-bottom-action-sheet.tsx
@@ -11,10 +11,10 @@ import {
   BottomActionSheetTrigger,
 } from '@/components/ui-unstable/bottom-action-sheet';
 import { ROUTES } from '@/constants/routes';
-import { generateUuid } from '@/lib/utils';
+import { generateId } from '@/lib/utils';
 import { type PropsWithTrigger } from '@/types/props';
 
-const categoryId = generateUuid();
+const categoryId = generateId();
 
 const UpdateCategoryPageBottomActionSheet = ({ trigger }: PropsWithTrigger) => {
   return (

--- a/features/user-handle-page/post-by-category-section.tsx
+++ b/features/user-handle-page/post-by-category-section.tsx
@@ -49,10 +49,10 @@ const PostByCategorySection = ({ user }: PostByCategorySectionProps) => {
         <div className="flex flex-col">
           {posts.map(
             (
-              { author, title, slug, description, thumbnail, createdAt },
+              { author, title, id: postId, description, thumbnail, createdAt },
               index,
             ) => (
-              <Link href={ROUTES.POST_OF(author.handle, slug)} key={index}>
+              <Link href={ROUTES.POST_OF(author.handle, postId)} key={index}>
                 <div className="px-4 py-3">
                   <StackedPostCard
                     username={author.username}

--- a/features/user-handle-page/user-handle-page-trending-post-section.tsx
+++ b/features/user-handle-page/user-handle-page-trending-post-section.tsx
@@ -33,10 +33,17 @@ const UserHandlePageTrendingPostSection = ({
           <div className="mr-4 flex gap-3 pb-4">
             {posts.map(
               (
-                { author, title, slug, description, thumbnail, createdAt },
+                {
+                  author,
+                  title,
+                  id: postId,
+                  description,
+                  thumbnail,
+                  createdAt,
+                },
                 index,
               ) => (
-                <Link href={ROUTES.POST_OF(author.handle, slug)} key={index}>
+                <Link href={ROUTES.POST_OF(author.handle, postId)} key={index}>
                   <HorizontalScrollablePostCard
                     username={author.username}
                     userHandle={author.handle}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -77,13 +77,13 @@ const generateUser = (): User => {
 const generatePost = (initialAuthor?: User): Post => {
   const author = initialAuthor ?? generateUser();
 
-  const { title, slug, description } = sample(BLCCU_DUMMY_DATASET.POST.BASICS);
+  const { title, id, description } = sample(BLCCU_DUMMY_DATASET.POST.BASICS);
 
   const thumbnail = sample(BLCCU_DUMMY_DATASET.POST.THUMBNAIL_IMAGES);
 
   const createdAt = randomDate(new Date(2023, 11, 1), new Date());
 
-  return { author, title, slug, description, thumbnail, createdAt };
+  return { author, title, id, description, thumbnail, createdAt };
 };
 
 const generateUsers = (size: number): User[] => {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,5 +1,4 @@
 import { type ClassValue, clsx } from 'clsx';
-import { type UUID } from 'crypto';
 import { twMerge } from 'tailwind-merge';
 
 import { BLCCU_DUMMY_DATASET } from '@/constants/dummy';
@@ -44,6 +43,10 @@ const sampleSize = <T extends unknown>(array: T[], size: number): T[] => {
 
 const randomInt = (min: number, max: number) => {
   return Math.floor(Math.random() * (max - min + 1) + min);
+};
+
+const generateId = () => {
+  return randomInt(1, 142857);
 };
 
 const randomDate = (start: Date, end: Date) => {
@@ -98,15 +101,6 @@ const generatePosts = (size: number, initialAuthor?: User): Post[] => {
   return Array.from({ length: size }, () => generatePost());
 };
 
-const generateUuid = (): UUID => {
-  const s4 = () =>
-    Math.floor((1 + Math.random()) * 0x10000)
-      .toString(16)
-      .substring(1);
-
-  return `${s4()}${s4()}-${s4()}-${s4()}-${s4()}-${s4()}${s4()}${s4()}`;
-};
-
 const generateCategory = (): Category => {
   const { id, name } = sample(BLCCU_DUMMY_DATASET.CATEGORIES);
   const count = randomInt(0, 100);
@@ -121,19 +115,19 @@ const generateCategories = (size: number) => {
 const generateCommentWithReplies = (): CommentWithReplies => {
   const replyCount = randomInt(0, 5);
 
-  const uuid = generateUuid();
+  const id = generateId();
 
   const comment: Comment = {
-    uuid,
+    id,
     user: generateUser(),
     content: sample(BLCCU_DUMMY_DATASET.COMMENTS),
   };
 
   const replies: Reply[] = Array.from({ length: replyCount }, () => ({
-    uuid: generateUuid(),
+    id: generateId(),
     user: generateUser(),
     content: sample(BLCCU_DUMMY_DATASET.COMMENTS),
-    parent: uuid,
+    parent: id,
   }));
 
   return { comment, replies };
@@ -150,11 +144,11 @@ export {
   generateCategory,
   generateCommentWithReplies,
   generateCommentsWithReplies,
+  generateId,
   generatePost,
   generatePosts,
   generateUser,
   generateUsers,
-  generateUuid,
   randomDate,
   randomInt,
   sample,

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -21,8 +21,8 @@ const nextConfig = {
         destination: '/users/:userHandle/select-category',
       },
       {
-        source: '/@:userHandle/:slug/:path*',
-        destination: '/users/:userHandle/posts/:slug/:path*',
+        source: '/@:userHandle/:postId/:path*',
+        destination: '/users/:userHandle/posts/:postId/:path*',
       },
       {
         source: '/proxy-api/:path*',

--- a/types/mocking-entity.d.ts
+++ b/types/mocking-entity.d.ts
@@ -1,5 +1,3 @@
-import { type UUID } from 'crypto';
-
 type User = {
   username: string;
   handle: string;
@@ -28,16 +26,16 @@ type Category = {
 };
 
 type Comment = {
-  uuid: UUID;
+  id: number;
   user: User;
   content: string;
 };
 
 type Reply = {
-  uuid: UUID;
+  id: number;
   user: User;
   content: string;
-  parent: UUID;
+  parent: number;
 };
 
 type CommentWithReplies = {

--- a/types/mocking-entity.d.ts
+++ b/types/mocking-entity.d.ts
@@ -11,9 +11,9 @@ type User = {
 };
 
 type Post = {
+  id: number;
   author: User;
   title: string;
-  slug: string;
   description: string;
   thumbnail: string;
   createdAt: Date;


### PR DESCRIPTION
## Summary

https://github.com/DevKor-github/team-sprint-blccu-backend/issues/24 에 대하여 BE와 커뮤니케이션 후 수정사항을 반영하는 PR입니다. 

## Describe your changes

### 라우팅 변경
변경사항은 다음과 같습니다. 
- /users/[userHandle]/posts/[slug] -> /users/[userHandle]/posts/[postId]로 라우팅 교체
- commentId 등에서 사용하던 UUID를 number로 수정

최신화된 라우팅 표는 [여기](https://github.com/DevKor-github/team-sprint-blccu-frontend/wiki/%EB%9D%BC%EC%9A%B0%ED%8C%85-%EA%B5%AC%EC%A1%B0)에서 확인 가능합니다. 

### userHandle 사용
유저 페이지에 대한 URL에 userId 대신 userHandle을 사용하는 안에 대하여 BE에서 동의하였습니다. 

다음의 변경이 예상됩니다. 
- 온보딩 플로우에 유저 핸들 설정 기능 추가
- 설정에 유저 핸들 변경 기능 추가
