### PR TITLE
feat: sticker 로직을 react-konva로 대체

### DIFF
--- a/app/(signed-in-only)/write/_components/sticker-layer.tsx
+++ b/app/(signed-in-only)/write/_components/sticker-layer.tsx
@@ -1,20 +1,65 @@
 'use client';
 
-import { Sticker } from '@/app/(signed-in-only)/write/_components/sticker';
-import { useStickersStore } from '@/app/(signed-in-only)/write/_store/use-stickers-store';
+import { useState } from 'react';
+import { Layer, Stage } from 'react-konva';
 
-const StickerLayer = () => {
-  const { stickers } = useStickersStore();
+import type Konva from 'konva';
+
+import { Sticker } from '@/app/(signed-in-only)/write/_components/sticker';
+import {
+  type Sticker as StickerType,
+  useStickersStore,
+} from '@/app/(signed-in-only)/write/_store/use-stickers-store';
+
+type StickerLayerProps = {
+  height: number;
+};
+
+const StickerLayer = ({ height }: StickerLayerProps) => {
+  const { stickers, setStickers } = useStickersStore();
+
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  const checkDeselect = (
+    e: Konva.KonvaEventObject<MouseEvent> | Konva.KonvaEventObject<TouchEvent>,
+  ) => {
+    // deselect when clicked on empty area
+    const clickedOnEmpty = e.target === e.target.getStage();
+    if (clickedOnEmpty) {
+      setSelectedId(null);
+    }
+  };
 
   return (
-    <div className="absolute">
-      {Object.values(stickers).map((sticker) => (
-        <Sticker
-          key={sticker.clientId}
-          clientId={sticker.clientId.toString()}
-        />
-      ))}
-    </div>
+    <Stage
+      width={Math.min(window.innerWidth, 640)}
+      height={height}
+      onMouseDown={checkDeselect}
+      onTouchStart={checkDeselect}
+      className="absolute"
+    >
+      <Layer>
+        {Object.values(stickers).map((sticker) => (
+          <Sticker
+            key={sticker.clientId}
+            sticker={sticker}
+            isSelected={sticker.clientId === selectedId}
+            onSelect={() => {
+              setSelectedId(sticker.clientId);
+            }}
+            onChange={(newAttrs: StickerType) => {
+              const newStickers = { ...stickers };
+
+              newStickers[sticker.clientId] = {
+                ...newAttrs,
+              };
+
+              setStickers(newStickers);
+            }}
+          />
+        ))}
+      </Layer>
+    </Stage>
   );
 };
 

--- a/app/(signed-in-only)/write/_components/sticker.tsx
+++ b/app/(signed-in-only)/write/_components/sticker.tsx
@@ -1,282 +1,74 @@
-'use client';
+import { useEffect, useRef } from 'react';
+import { Image, Transformer } from 'react-konva';
 
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import type Konva from 'konva';
+import useImage from 'use-image';
 
 import { useCaptureModeStore } from '@/app/(signed-in-only)/write/_store/use-capture-mode-store';
-import { useEditorModeStore } from '@/app/(signed-in-only)/write/_store/use-editor-mode-store';
-import { useStickersStore } from '@/app/(signed-in-only)/write/_store/use-stickers-store';
-import { cn } from '@/lib/utils';
+import { type Sticker as StickerType } from '@/app/(signed-in-only)/write/_store/use-stickers-store';
 
-interface StickerProps {
-  clientId: string;
-}
+type StickerProps = {
+  sticker: StickerType;
+  isSelected: boolean;
+  onSelect: () => void;
+  onChange: (newAttrs: StickerType) => void;
+};
 
-interface Transform {
-  scale: number;
-  angle: number;
-  posX: number;
-  posY: number;
-}
+const Sticker = ({ sticker, isSelected, onSelect, onChange }: StickerProps) => {
+  const shapeRef = useRef<Konva.Image>(null);
+  const trRef = useRef<Konva.Transformer>(null);
 
-const Sticker = ({ clientId }: StickerProps) => {
-  // DB에서 가져온 이미지 정보를 이용해 스티커를 생성하는 컴포넌트
+  const [image] = useImage(sticker.src, 'anonymous');
 
-  const {
-    stickers,
-    focused,
-    setFocused,
-    editPosition,
-    editSize,
-    deleteSticker,
-  } = useStickersStore();
   const { captureMode } = useCaptureModeStore();
-  const { editorMode } = useEditorModeStore();
-
-  const stickerProps = stickers[clientId];
-
-  const [transform, setTransform] = useState<Transform>({
-    scale: 1,
-    angle: 0,
-    posX: 100,
-    posY: 100,
-  });
 
   useEffect(() => {
-    if (stickerProps) {
-      setTransform({
-        scale: stickerProps.scale,
-        angle: stickerProps.angle,
-        posX: stickerProps.posX,
-        posY: stickerProps.posY,
-      });
+    if (shapeRef.current === null || trRef.current === null) {
+      return;
     }
-  }, []);
 
-  const transformRef = useRef<Transform>(transform);
-  const containerRef = useRef<HTMLDivElement>(null);
-  const resizingRef = useRef(false);
-  const draggingRef = useRef(false);
-  const lastPositionRef = useRef<{ x: number; y: number } | null>(null);
-  const throttleTimeoutRef = useRef<number | null>(null);
-
-  // TODO: type this
-  const throttle = (func: (...args: any[]) => void, delay: number) => {
-    return (...args: any[]) => {
-      if (throttleTimeoutRef.current === null) {
-        func(...args);
-        throttleTimeoutRef.current = window.setTimeout(() => {
-          throttleTimeoutRef.current = null;
-        }, delay);
-      }
-    };
-  };
-
-  const handleMouseOrTouchMove = useCallback(
-    (event: TouchEvent | MouseEvent): void => {
-      const clientX =
-        event instanceof TouchEvent ? event.touches[0].clientX : event.clientX;
-      const clientY =
-        event instanceof TouchEvent ? event.touches[0].clientY : event.clientY;
-
-      if (focused === clientId) {
-        if (resizingRef.current) {
-          // Resizing
-          if (!containerRef.current) return;
-          event.stopPropagation();
-
-          const rect = containerRef.current.getBoundingClientRect();
-          const center = {
-            x: rect.left + rect.width / 2,
-            y: rect.top + rect.height / 2,
-          };
-
-          const dx = clientX - center.x;
-          const dy = clientY - center.y;
-          const distance = Math.sqrt(dx * dx + dy * dy);
-          const angle = Math.atan2(dy, dx) * (180 / Math.PI);
-
-          setTransform((prev) => ({
-            ...prev,
-            scale: distance / (rect.width / 2) || 1,
-            angle: angle - 90,
-          }));
-        } else if (draggingRef.current && lastPositionRef.current) {
-          // Dragging
-          event.stopPropagation();
-
-          const dx = clientX - lastPositionRef.current.x;
-          const dy = clientY - lastPositionRef.current.y;
-
-          if (Number.isNaN(dx) || Number.isNaN(dy)) {
-            return;
-          }
-
-          setTransform((prev) => ({
-            ...prev,
-            posX: prev.posX + dx,
-            posY: prev.posY + dy,
-          }));
-
-          lastPositionRef.current = { x: clientX, y: clientY };
-        }
-      }
-    },
-    [clientId, focused],
-  );
-
-  const throttledMouseOrTouchMove = useCallback(
-    throttle(handleMouseOrTouchMove, 50),
-    [handleMouseOrTouchMove],
-  );
-
-  const handleMouseOrTouchEnd = useCallback((): void => {
-    draggingRef.current = false;
-    resizingRef.current = false;
-    transformRef.current = transform;
-    editPosition({
-      clientId,
-      posX: transform.posX,
-      posY: transform.posY,
-    });
-    editSize({
-      clientId,
-      scale: transform.scale,
-      angle: transform.angle,
-    });
-  }, [transform]);
-
-  const handleMouseDown = (event: React.MouseEvent): void => {
-    event.stopPropagation();
-    setFocused(clientId);
-    draggingRef.current = true;
-    lastPositionRef.current = { x: event.clientX, y: event.clientY };
-  };
-
-  const handleTouchStart = (event: React.TouchEvent): void => {
-    event.stopPropagation();
-    setFocused(clientId);
-    draggingRef.current = true;
-    if (event.touches.length > 0) {
-      lastPositionRef.current = {
-        x: event.touches[0].clientX,
-        y: event.touches[0].clientY,
-      };
+    if (isSelected) {
+      // we need to attach transformer manually
+      trRef.current.nodes([shapeRef.current]);
+      trRef.current.getLayer()?.batchDraw();
     }
-  };
-
-  const handleResizeMouseDown = (event: React.MouseEvent): void => {
-    event.stopPropagation();
-    setFocused(clientId);
-    resizingRef.current = true;
-  };
-
-  const handleResizeTouchStart = (event: React.TouchEvent): void => {
-    event.stopPropagation();
-    setFocused(clientId);
-    resizingRef.current = true;
-  };
-
-  // Add and remove global event listeners for mouse/touch movement and end events
-  useEffect(() => {
-    const handleMove = (event: TouchEvent | MouseEvent) =>
-      throttledMouseOrTouchMove(event);
-    const handleEnd = () => handleMouseOrTouchEnd();
-
-    document.addEventListener('mousemove', handleMove);
-    document.addEventListener('touchmove', handleMove, { passive: false });
-    document.addEventListener('mouseup', handleEnd);
-    document.addEventListener('touchend', handleEnd);
-
-    return () => {
-      document.removeEventListener('mousemove', handleMove);
-      document.removeEventListener('touchmove', handleMove);
-      document.removeEventListener('mouseup', handleEnd);
-      document.removeEventListener('touchend', handleEnd);
-    };
-  }, [throttledMouseOrTouchMove, handleMouseOrTouchEnd]);
-
-  const resizeControlStyle = {
-    position: 'absolute',
-    width: '24px',
-    height: '24px',
-    transform: `scale(${1 / transform.scale})`,
-    border: '2px solid black',
-    backgroundColor: 'white',
-    borderRadius: '50%',
-    touchAction: 'none',
-    cursor: 'pointer',
-  };
-
-  const deleteControlStyle = {
-    position: 'absolute',
-    width: '24px',
-    height: '24px',
-    transform: `scale(${1 / transform.scale})`,
-    backgroundColor: 'red',
-    borderRadius: '50%',
-    touchAction: 'none',
-    cursor: 'pointer',
-  };
+  }, [isSelected, shapeRef, trRef]);
 
   return (
-    <div>
-      <div
-        ref={containerRef}
-        style={{
-          position: 'absolute',
-          touchAction: 'none',
-          width: '200px',
-          top: transform.posY,
-          left: transform.posX,
-          transform: `rotate(${transform.angle}deg) scale(${transform.scale})`,
-          transformOrigin: 'center',
-          transition: 'transform 0.1s ease',
-          border:
-            focused === clientId && !captureMode ? '2px solid black' : 'none',
+    <>
+      <Image
+        image={image}
+        width={300}
+        height={300}
+        onClick={onSelect}
+        onTap={onSelect}
+        ref={shapeRef}
+        draggable
+        onDragEnd={(e) => {
+          onChange({
+            ...sticker,
+            posX: e.target.x(),
+            posY: e.target.y(),
+          });
         }}
-        className={cn(
-          editorMode === 'write' ? 'pointer-events-none z-0' : 'z-10',
-        )}
-        id={stickerProps.clientId.toString()}
-        onTouchStart={handleTouchStart}
-        onMouseDown={handleMouseDown}
-      >
-        <img
-          src={stickerProps.src}
-          alt="sticker"
-          className="h-full w-full object-contain"
-          crossOrigin="anonymous"
+      />
+      {isSelected && !captureMode && (
+        <Transformer
+          ref={trRef}
+          flipEnabled={false}
+          boundBoxFunc={(oldBox, newBox) => {
+            // limit resize
+            if (Math.abs(newBox.width) < 5 || Math.abs(newBox.height) < 5) {
+              return oldBox;
+            }
+            return newBox;
+          }}
         />
-        {focused === clientId && !captureMode ? (
-          <>
-            <div
-              id="resize-control"
-              style={{
-                ...resizeControlStyle,
-                position: 'absolute',
-                bottom: '-12px',
-                right: '-12px',
-              }}
-              onMouseDown={handleResizeMouseDown}
-              onTouchStart={handleResizeTouchStart}
-            />
-            <div
-              id="delete-control"
-              style={{
-                ...deleteControlStyle,
-                position: 'absolute',
-                top: '-12px',
-                right: '-12px',
-              }}
-              onClick={() => {
-                deleteSticker(stickerProps);
-              }}
-            />
-          </>
-        ) : null}
-      </div>
-    </div>
+      )}
+    </>
   );
 };
 
 export { Sticker };
+
+// Ref: https://konvajs.org/docs/react/Transformer.html

--- a/app/(signed-in-only)/write/_components/sticker__legacy.tsx
+++ b/app/(signed-in-only)/write/_components/sticker__legacy.tsx
@@ -1,0 +1,282 @@
+'use client';
+
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+
+import { useCaptureModeStore } from '@/app/(signed-in-only)/write/_store/use-capture-mode-store';
+import { useEditorModeStore } from '@/app/(signed-in-only)/write/_store/use-editor-mode-store';
+import { useStickersStore } from '@/app/(signed-in-only)/write/_store/use-stickers-store';
+import { cn } from '@/lib/utils';
+
+interface Sticker__LegacyProps {
+  clientId: string;
+}
+
+interface Transform {
+  scale: number;
+  angle: number;
+  posX: number;
+  posY: number;
+}
+
+const Sticker__Legacy = ({ clientId }: Sticker__LegacyProps) => {
+  // DB에서 가져온 이미지 정보를 이용해 스티커를 생성하는 컴포넌트
+
+  const {
+    stickers,
+    focused,
+    setFocused,
+    editPosition,
+    editSize,
+    deleteSticker,
+  } = useStickersStore();
+  const { captureMode } = useCaptureModeStore();
+  const { editorMode } = useEditorModeStore();
+
+  const stickerProps = stickers[clientId];
+
+  const [transform, setTransform] = useState<Transform>({
+    scale: 1,
+    angle: 0,
+    posX: 100,
+    posY: 100,
+  });
+
+  useEffect(() => {
+    if (stickerProps) {
+      setTransform({
+        scale: stickerProps.scale,
+        angle: stickerProps.angle,
+        posX: stickerProps.posX,
+        posY: stickerProps.posY,
+      });
+    }
+  }, []);
+
+  const transformRef = useRef<Transform>(transform);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const resizingRef = useRef(false);
+  const draggingRef = useRef(false);
+  const lastPositionRef = useRef<{ x: number; y: number } | null>(null);
+  const throttleTimeoutRef = useRef<number | null>(null);
+
+  // TODO: type this
+  const throttle = (func: (...args: any[]) => void, delay: number) => {
+    return (...args: any[]) => {
+      if (throttleTimeoutRef.current === null) {
+        func(...args);
+        throttleTimeoutRef.current = window.setTimeout(() => {
+          throttleTimeoutRef.current = null;
+        }, delay);
+      }
+    };
+  };
+
+  const handleMouseOrTouchMove = useCallback(
+    (event: TouchEvent | MouseEvent): void => {
+      const clientX =
+        event instanceof TouchEvent ? event.touches[0].clientX : event.clientX;
+      const clientY =
+        event instanceof TouchEvent ? event.touches[0].clientY : event.clientY;
+
+      if (focused === clientId) {
+        if (resizingRef.current) {
+          // Resizing
+          if (!containerRef.current) return;
+          event.stopPropagation();
+
+          const rect = containerRef.current.getBoundingClientRect();
+          const center = {
+            x: rect.left + rect.width / 2,
+            y: rect.top + rect.height / 2,
+          };
+
+          const dx = clientX - center.x;
+          const dy = clientY - center.y;
+          const distance = Math.sqrt(dx * dx + dy * dy);
+          const angle = Math.atan2(dy, dx) * (180 / Math.PI);
+
+          setTransform((prev) => ({
+            ...prev,
+            scale: distance / (rect.width / 2) || 1,
+            angle: angle - 90,
+          }));
+        } else if (draggingRef.current && lastPositionRef.current) {
+          // Dragging
+          event.stopPropagation();
+
+          const dx = clientX - lastPositionRef.current.x;
+          const dy = clientY - lastPositionRef.current.y;
+
+          if (Number.isNaN(dx) || Number.isNaN(dy)) {
+            return;
+          }
+
+          setTransform((prev) => ({
+            ...prev,
+            posX: prev.posX + dx,
+            posY: prev.posY + dy,
+          }));
+
+          lastPositionRef.current = { x: clientX, y: clientY };
+        }
+      }
+    },
+    [clientId, focused],
+  );
+
+  const throttledMouseOrTouchMove = useCallback(
+    throttle(handleMouseOrTouchMove, 50),
+    [handleMouseOrTouchMove],
+  );
+
+  const handleMouseOrTouchEnd = useCallback((): void => {
+    draggingRef.current = false;
+    resizingRef.current = false;
+    transformRef.current = transform;
+    editPosition({
+      clientId,
+      posX: transform.posX,
+      posY: transform.posY,
+    });
+    editSize({
+      clientId,
+      scale: transform.scale,
+      angle: transform.angle,
+    });
+  }, [transform]);
+
+  const handleMouseDown = (event: React.MouseEvent): void => {
+    event.stopPropagation();
+    setFocused(clientId);
+    draggingRef.current = true;
+    lastPositionRef.current = { x: event.clientX, y: event.clientY };
+  };
+
+  const handleTouchStart = (event: React.TouchEvent): void => {
+    event.stopPropagation();
+    setFocused(clientId);
+    draggingRef.current = true;
+    if (event.touches.length > 0) {
+      lastPositionRef.current = {
+        x: event.touches[0].clientX,
+        y: event.touches[0].clientY,
+      };
+    }
+  };
+
+  const handleResizeMouseDown = (event: React.MouseEvent): void => {
+    event.stopPropagation();
+    setFocused(clientId);
+    resizingRef.current = true;
+  };
+
+  const handleResizeTouchStart = (event: React.TouchEvent): void => {
+    event.stopPropagation();
+    setFocused(clientId);
+    resizingRef.current = true;
+  };
+
+  // Add and remove global event listeners for mouse/touch movement and end events
+  useEffect(() => {
+    const handleMove = (event: TouchEvent | MouseEvent) =>
+      throttledMouseOrTouchMove(event);
+    const handleEnd = () => handleMouseOrTouchEnd();
+
+    document.addEventListener('mousemove', handleMove);
+    document.addEventListener('touchmove', handleMove, { passive: false });
+    document.addEventListener('mouseup', handleEnd);
+    document.addEventListener('touchend', handleEnd);
+
+    return () => {
+      document.removeEventListener('mousemove', handleMove);
+      document.removeEventListener('touchmove', handleMove);
+      document.removeEventListener('mouseup', handleEnd);
+      document.removeEventListener('touchend', handleEnd);
+    };
+  }, [throttledMouseOrTouchMove, handleMouseOrTouchEnd]);
+
+  const resizeControlStyle = {
+    position: 'absolute',
+    width: '24px',
+    height: '24px',
+    transform: `scale(${1 / transform.scale})`,
+    border: '2px solid black',
+    backgroundColor: 'white',
+    borderRadius: '50%',
+    touchAction: 'none',
+    cursor: 'pointer',
+  };
+
+  const deleteControlStyle = {
+    position: 'absolute',
+    width: '24px',
+    height: '24px',
+    transform: `scale(${1 / transform.scale})`,
+    backgroundColor: 'red',
+    borderRadius: '50%',
+    touchAction: 'none',
+    cursor: 'pointer',
+  };
+
+  return (
+    <div>
+      <div
+        ref={containerRef}
+        style={{
+          position: 'absolute',
+          touchAction: 'none',
+          width: '200px',
+          top: transform.posY,
+          left: transform.posX,
+          transform: `rotate(${transform.angle}deg) scale(${transform.scale})`,
+          transformOrigin: 'center',
+          transition: 'transform 0.1s ease',
+          border:
+            focused === clientId && !captureMode ? '2px solid black' : 'none',
+        }}
+        className={cn(
+          editorMode === 'write' ? 'pointer-events-none z-0' : 'z-10',
+        )}
+        id={stickerProps.clientId.toString()}
+        onTouchStart={handleTouchStart}
+        onMouseDown={handleMouseDown}
+      >
+        <img
+          src={stickerProps.src}
+          alt="sticker"
+          className="h-full w-full object-contain"
+          crossOrigin="anonymous"
+        />
+        {focused === clientId && !captureMode ? (
+          <>
+            <div
+              id="resize-control"
+              style={{
+                ...resizeControlStyle,
+                position: 'absolute',
+                bottom: '-12px',
+                right: '-12px',
+              }}
+              onMouseDown={handleResizeMouseDown}
+              onTouchStart={handleResizeTouchStart}
+            />
+            <div
+              id="delete-control"
+              style={{
+                ...deleteControlStyle,
+                position: 'absolute',
+                top: '-12px',
+                right: '-12px',
+              }}
+              onClick={() => {
+                deleteSticker(stickerProps);
+              }}
+            />
+          </>
+        ) : null}
+      </div>
+    </div>
+  );
+};
+
+// export { Sticker__Legacy };

--- a/app/(signed-in-only)/write/_components/write-page-content.tsx
+++ b/app/(signed-in-only)/write/_components/write-page-content.tsx
@@ -8,7 +8,7 @@ import { WritePageAppBar } from '@/app/(signed-in-only)/write/_components/write-
 import { useEditorContentsStore } from '@/app/(signed-in-only)/write/_store/use-editor-contents-store';
 
 const WritePageContent = () => {
-  const mainContentRef = useRef(null);
+  const mainContentRef = useRef<HTMLDivElement>(null);
 
   const { background, setMainContainerElement } = useEditorContentsStore();
 
@@ -29,7 +29,7 @@ const WritePageContent = () => {
             background !== null ? `url(${background.imageUrl})` : 'none',
         }}
       >
-        <StickerLayer />
+        <StickerLayer height={mainContentRef.current?.clientHeight ?? 0} />
         <EditorLayer />
       </div>
     </div>

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "tailwind-merge": "^2.3.0",
     "tailwindcss-animate": "^1.0.7",
     "tiptap-extension-font-size": "^1.2.0",
+    "use-image": "^1.1.1",
     "uuid": "^10.0.0",
     "zod": "^3.23.8",
     "zustand": "^4.5.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -182,6 +182,9 @@ importers:
       tiptap-extension-font-size:
         specifier: ^1.2.0
         version: 1.2.0(@tiptap/pm@2.4.0)
+      use-image:
+        specifier: ^1.1.1
+        version: 1.1.1(react-dom@18.2.0(react@18.3.1))(react@18.3.1)
       uuid:
         specifier: ^10.0.0
         version: 10.0.0
@@ -6959,6 +6962,12 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  use-image@1.1.1:
+    resolution: {integrity: sha512-n4YO2k8AJG/BcDtxmBx8Aa+47kxY5m335dJiCQA5tTeVU4XdhrhqR6wT0WISRXwdMEOv5CSjqekDZkEMiiWaYQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
 
   use-sidecar@1.1.2:
     resolution: {integrity: sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==}
@@ -15130,6 +15139,11 @@ snapshots:
       tslib: 2.6.2
     optionalDependencies:
       '@types/react': 18.2.74
+
+  use-image@1.1.1(react-dom@18.2.0(react@18.3.1))(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-dom: 18.2.0(react@18.3.1)
 
   use-sidecar@1.1.2(@types/react@18.2.74)(react@18.3.1):
     dependencies:


### PR DESCRIPTION
## Summary

기존 **꾸미기** 탭의 로직을 `transform: translate~` 방식에서 `react-konva`로 대체하였습니다. 

## Describe your changes

AS-IS
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/7d1df368-ebae-43c9-b43c-41b66f39b737">


> 아직 버그가 많습니다. (특히 꾸미기 탭의 정보를 BE와 교환하는 쪽에 문제가 많음)
> 예상 오류 feature : 임시저장, 임시저장 불러오기, 게시글 수정

기존 `sticker.tsx` 코드는 삭제하진 않고 `sticker__legacy.tsx` 파일로 이름변경하였음을 알립니다.

### 기술 스택 변경 이유 짤막 기록
1. window.innerWidth는 넓지만 width 제한을 640px로 해놓은 상황임. 때문에 스티커가 640px을 넘어가도 여전히 이동하는 문제가 있었음. (아래 사진 참고) 
2. 기기, 브라우저에 따라 MouseEvent 및 TouchEvent 를 직접 관리하는 것이 *매우* 어려웠고, 기존 로직은 스티커 조작 시 버그가 많이 발생하였음. 

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/376b0066-a0e5-4fcd-9e66-3ff367f61e0b">


###  참고한 링크

- https://konvajs.org/docs/react/Transformer.html
- https://konvajs.org/docs/react/Images.html

## Issue number and link
